### PR TITLE
Move redux functionality into OutputWrapperThingy and out of webconsole

### DIFF
--- a/devtools/client/webconsole/new-console-output/output-wrapper-thingy.js
+++ b/devtools/client/webconsole/new-console-output/output-wrapper-thingy.js
@@ -3,17 +3,34 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 
-// React
+// React & Redux
 const React = require("devtools/client/shared/vendor/react");
 const ReactDOM = require("devtools/client/shared/vendor/react-dom");
 const { Provider } = require("devtools/client/shared/vendor/react-redux");
+const { combineReducers } = require("devtools/client/shared/vendor/redux");
+
+const createStore = require("devtools/client/shared/redux/create-store")();
+
+const { reducers } = require("./reducers/index");
+const store = createStore(combineReducers(reducers));
+
 const DummyChildComponent = React.createFactory(require("./dummy-child-component"));
 
-function OutputWrapperThingy(parentNode, store) {
+function OutputWrapperThingy(parentNode) {
   let childComponent = DummyChildComponent({});
   let provider = React.createElement(Provider, { store: store }, childComponent);
   this.body = ReactDOM.render(provider, parentNode);
 }
+
+OutputWrapperThingy.prototype = {
+  dispatchMessageAdd: (message) => {
+    let action = {
+      type: "MESSAGE_ADD",
+      message
+    }
+    store.dispatch(action)
+  }
+};
 
 // Exports from this module
 module.exports = OutputWrapperThingy;

--- a/devtools/client/webconsole/webconsole.js
+++ b/devtools/client/webconsole/webconsole.js
@@ -20,13 +20,6 @@ const Services = require("Services");
 // React & Redux
 const React = require("devtools/client/shared/vendor/react");
 const ReactDOM = require("devtools/client/shared/vendor/react-dom");
-const { Provider } = require("devtools/client/shared/vendor/react-redux");
-const { combineReducers } = require("devtools/client/shared/vendor/redux");
-
-const createStore = require("devtools/client/shared/redux/create-store")();
-
-const { reducers } = require("./new-console-output/reducers/index");
-const store = createStore(combineReducers(reducers));
 
 loader.lazyServiceGetter(this, "clipboardHelper",
                          "@mozilla.org/widget/clipboardhelper;1",
@@ -544,7 +537,7 @@ WebConsoleFrame.prototype = {
       this.experimentalOutputNode = this.outputNode.cloneNode();
       this.outputNode.hidden = true;
       this.outputNode.parentNode.appendChild(this.experimentalOutputNode);
-      this.newConsoleOutput = new this.window.NewConsoleOutput(this.experimentalOutputNode, store);
+      this.newConsoleOutput = new this.window.NewConsoleOutput(this.experimentalOutputNode);
       console.log("Created newConsoleOutput", this.newConsoleOutput);
     }
 
@@ -1278,11 +1271,7 @@ WebConsoleFrame.prototype = {
       case "assert":
       case "debug": {
         if (this.SUPER_FRONTEND_EXPERIMENT) {
-          let action = {
-            type: "MESSAGE_ADD",
-            message
-          }
-          store.dispatch(action)
+          this.newConsoleOutput.dispatchMessageAdd(message);
         } else {
           let msg = new Messages.ConsoleGeneric(message);
           node = msg.init(this.output).render().element;


### PR DESCRIPTION
We'll need to be explicit about what sorts of things can be dispatched from the
webconsole frontend by defining it on OutputWrapperThingy but it makes the integration
points smaller
