### PR TITLE
Handle console.log() messages in webconsole. r=bgrins

### DIFF
--- a/devtools/client/webconsole/new-console-output/actions/messages.js
+++ b/devtools/client/webconsole/new-console-output/actions/messages.js
@@ -10,10 +10,10 @@ const {
   MESSAGES_CLEAR
 } = require("../constants");
 
-exports.messageAdd = function messageAdd(message) {
+exports.messageAdd = function messageAdd(packet) {
   return {
     type: MESSAGE_ADD,
-    message: message
+    packet: packet
   };
 };
 

--- a/devtools/client/webconsole/new-console-output/components/console-output.js
+++ b/devtools/client/webconsole/new-console-output/components/console-output.js
@@ -7,13 +7,15 @@ const React = require("devtools/client/shared/vendor/react");
 const { connect } = require("devtools/client/shared/vendor/react-redux");
 const DOM = React.DOM;
 
-var DummyChildComponent = React.createClass({
-  displayName: "DummyChildComponent",
+const MessageWrapper = React.createFactory(require("devtools/client/webconsole/new-console-output/components/message-wrapper").MessageWrapper);
+
+const ConsoleOutput = React.createClass({
+  displayName: "ConsoleOutput",
 
   render() {
-    let messageNodes = this.props.messages.map(function(message) {
+    let messageNodes = this.props.messagePackets.map(function(packet) {
       return (
-        DOM.div({}, message.arguments.join(" "))
+        MessageWrapper({ packet })
       );
     });
     return (
@@ -24,8 +26,8 @@ var DummyChildComponent = React.createClass({
 
 const mapStateToProps = (state) => {
   return {
-    messages: state.messages
+    messagePackets: state.messages
   };
 };
 
-module.exports = connect(mapStateToProps)(DummyChildComponent);
+module.exports = connect(mapStateToProps)(ConsoleOutput);

--- a/devtools/client/webconsole/new-console-output/components/message-types/console-api-call.js
+++ b/devtools/client/webconsole/new-console-output/components/message-types/console-api-call.js
@@ -1,0 +1,35 @@
+/* -*- indent-tabs-mode: nil; js-indent-level: 2 -*- */
+/* vim: set ft=javascript ts=2 et sw=2 tw=80: */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+// React & Redux
+const {
+  createClass,
+  DOM: dom,
+  PropTypes
+} = require("devtools/client/shared/vendor/react");
+
+const ConsoleApiCall = createClass({
+  displayName: "ConsoleApiCall",
+
+  propTypes: {
+    packet: PropTypes.object.isRequired,
+  },
+
+  render() {
+    const { message } = this.props.packet;
+    return dom.span({},
+      dom.span({className: "message-flex-body"},
+        dom.span({className: "message-body devtools-monospace"},
+          dom.span({className: "console-string"}, message.arguments.join(" "))
+        )
+      )
+    );
+  }
+});
+
+module.exports.ConsoleApiCall = ConsoleApiCall;

--- a/devtools/client/webconsole/new-console-output/components/message-types/moz.build
+++ b/devtools/client/webconsole/new-console-output/components/message-types/moz.build
@@ -3,14 +3,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-DIRS += [
-    'actions',
-    'components',
-    'reducers'
-]
-
 DevToolsModules(
-    'constants.js',
-    'main.js',
-    'output-wrapper-thingy.js',
+    'console-api-call.js',
 )

--- a/devtools/client/webconsole/new-console-output/components/message-wrapper.js
+++ b/devtools/client/webconsole/new-console-output/components/message-wrapper.js
@@ -1,0 +1,44 @@
+/* -*- indent-tabs-mode: nil; js-indent-level: 2 -*- */
+/* vim: set ft=javascript ts=2 et sw=2 tw=80: */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+// React & Redux
+const {
+  createClass,
+  createElement,
+  DOM: dom,
+  PropTypes
+} = require("devtools/client/shared/vendor/react");
+
+const MessageWrapper = createClass({
+  displayName: "MessageWrapper",
+
+  propTypes: {
+    packet: PropTypes.object.isRequired,
+  },
+
+  render() {
+    let MessageComponent = getMessageComponent(this.props.packet);
+    return dom.span({className: "message-body-wrapper"},
+      createElement(MessageComponent, { packet: this.props.packet })
+    );
+  }
+});
+
+function getMessageComponent(packet) {
+  let MessageComponent;
+  switch (packet.type) {
+    case "consoleAPICall":
+      MessageComponent = require("devtools/client/webconsole/new-console-output/components/message-types/console-api-call").ConsoleApiCall;
+      break;
+  }
+  return MessageComponent;
+}
+
+module.exports.MessageWrapper = MessageWrapper;
+// Exported so we can test it with unit tests.
+module.exports.getMessageComponent = getMessageComponent;

--- a/devtools/client/webconsole/new-console-output/components/moz.build
+++ b/devtools/client/webconsole/new-console-output/components/moz.build
@@ -4,13 +4,10 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 DIRS += [
-    'actions',
-    'components',
-    'reducers'
+    'message-types'
 ]
 
 DevToolsModules(
-    'constants.js',
-    'main.js',
-    'output-wrapper-thingy.js',
+    'console-output.js',
+    'message-wrapper.js'
 )

--- a/devtools/client/webconsole/new-console-output/output-wrapper-thingy.js
+++ b/devtools/client/webconsole/new-console-output/output-wrapper-thingy.js
@@ -19,10 +19,10 @@ const actions = require("devtools/client/webconsole/new-console-output/actions/m
 const { reducers } = require("./reducers/index");
 const store = createStore(combineReducers(reducers));
 
-const DummyChildComponent = React.createFactory(require("./dummy-child-component"));
+const ConsoleOutput = React.createFactory(require("devtools/client/webconsole/new-console-output/components/console-output"));
 
 function OutputWrapperThingy(parentNode) {
-  let childComponent = DummyChildComponent({});
+  let childComponent = ConsoleOutput({});
   let provider = React.createElement(Provider, { store: store }, childComponent);
   this.body = ReactDOM.render(provider, parentNode);
 }

--- a/devtools/client/webconsole/new-console-output/reducers/messages.js
+++ b/devtools/client/webconsole/new-console-output/reducers/messages.js
@@ -5,24 +5,19 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 
-const {
-  MESSAGE_ADD,
-  MESSAGES_CLEAR
-} = require("devtools/client/webconsole/new-console-output/constants");
+const Immutable = require("devtools/client/shared/vendor/immutable");
 
-/**
- * Filter displayed object properties.
- */
+const constants = require("devtools/client/webconsole/new-console-output/constants");
+
 function messages(state = [], action) {
   switch (action.type) {
-    case MESSAGE_ADD:
-      return state.concat([action.message]);
-    case MESSAGES_CLEAR:
+    case constants.MESSAGE_ADD:
+      return state.concat([action.packet]);
+    case constants.MESSAGES_CLEAR:
       return [];
   }
 
   return state;
 }
 
-// Exports from this module
 exports.messages = messages;

--- a/devtools/client/webconsole/new-console-output/test/actions/messages.test.js
+++ b/devtools/client/webconsole/new-console-output/test/actions/messages.test.js
@@ -13,11 +13,11 @@ const constants = require("devtools/client/webconsole/new-console-output/constan
 describe("Message action creator", function() {
   describe("messsageAdd()", function() {
     it("creates expected action", function() {
-      let message = {};
-      let action = actions.messageAdd(message);
+      let packet = {};
+      let action = actions.messageAdd(packet);
       expect(action).toEqual({
         type: constants.MESSAGE_ADD,
-        message: {}
+        packet: {}
       });
     });
   });

--- a/devtools/client/webconsole/new-console-output/test/components/console-api-call.test.js
+++ b/devtools/client/webconsole/new-console-output/test/components/console-api-call.test.js
@@ -1,0 +1,45 @@
+/* -*- indent-tabs-mode: nil; js-indent-level: 2 -*- */
+/* vim: set ft=javascript ts=2 et sw=2 tw=80: */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+// React & Redux
+const React = require("devtools/client/shared/vendor/react");
+const ReactDOM = require("devtools/client/shared/vendor/react-dom");
+const TestUtils = React.addons.TestUtils;
+
+const expect = require("expect");
+require("mocha-jsdom")();
+
+const { ConsoleApiCall } = require("devtools/client/webconsole/new-console-output/components/message-types/console-api-call");
+const data = require("devtools/client/webconsole/new-console-output/test/data/index");
+
+describe("ConsoleApiCall", function() {
+  it("should render a console.log call", function() {
+    const testData = data.get("console-log").get("default");
+    compareActualToExpected(testData);
+  });
+});
+
+function compareActualToExpected(testData) {
+  const packet = testData.responsePacket;
+  const actual = cleanActual(getHtml(packet));
+  expect(actual).toEqual(cleanExpected(testData.expectedHTML));
+}
+
+function getHtml(packet) {
+  const component = React.createElement(ConsoleApiCall, { packet }, {});
+  const renderedComponent = TestUtils.renderIntoDocument(component);
+  return ReactDOM.findDOMNode(renderedComponent).outerHTML;
+}
+
+function cleanActual(htmlString) {
+  return htmlString.replace(/ data-reactid=\".*?\"/g, "");
+}
+
+function cleanExpected(htmlString) {
+  return htmlString.replace(/(?:\r\n|\r|\n)\s*/g, "");
+}

--- a/devtools/client/webconsole/new-console-output/test/components/message-wrapper.test.js
+++ b/devtools/client/webconsole/new-console-output/test/components/message-wrapper.test.js
@@ -1,0 +1,45 @@
+/* -*- indent-tabs-mode: nil; js-indent-level: 2 -*- */
+/* vim: set ft=javascript ts=2 et sw=2 tw=80: */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+// React & Redux
+const React = require("devtools/client/shared/vendor/react");
+const TestUtils = React.addons.TestUtils;
+
+const expect = require("expect");
+
+const data = require("devtools/client/webconsole/new-console-output/test/data/index");
+const {
+  MessageWrapper,
+  getMessageComponent
+} = require("devtools/client/webconsole/new-console-output/components/message-wrapper");
+
+describe("MessageWrapper component", function() {
+  it("nests the correct child component based on the packet", function() {
+    const MessageWrapperFactory = React.createFactory(MessageWrapper);
+    const ConsoleApiCall = require("devtools/client/webconsole/new-console-output/components/message-types/console-api-call").ConsoleApiCall;
+
+    const test = MessageWrapperFactory({
+      packet: data.get("console-log").get("default").responsePacket
+    });
+
+    const renderer = TestUtils.createRenderer();
+    renderer.render(test, {});
+    let result = renderer.getRenderOutput();
+
+    expect(result.props.children.type).toEqual(ConsoleApiCall);
+  });
+
+  describe("getMessageComponent() helper", function() {
+    it("returns the right component for console-log packets", function() {
+      const ConsoleApiCall = require("devtools/client/webconsole/new-console-output/components/message-types/console-api-call").ConsoleApiCall;
+      const packet = data.get("console-log").get("default").responsePacket;
+      const result = getMessageComponent(packet);
+      expect(result).toBe(ConsoleApiCall);
+    });
+  });
+});

--- a/devtools/client/webconsole/new-console-output/test/data/console-log.js
+++ b/devtools/client/webconsole/new-console-output/test/data/console-log.js
@@ -32,7 +32,15 @@ data.set("default", {
       "category": "webdev"
     }
   },
-  consoleOutput: "foobar test"
+  expectedHTML: `
+    <span>
+      <span class="message-flex-body">
+        <span class="message-body devtools-monospace">
+          <span class="console-string">foobar test</span>
+        </span>
+      </span>
+    </span>
+    `
 });
 
 module.exports = data;

--- a/devtools/client/webconsole/new-console-output/test/data/index.js
+++ b/devtools/client/webconsole/new-console-output/test/data/index.js
@@ -1,0 +1,19 @@
+/* -*- indent-tabs-mode: nil; js-indent-level: 2 -*- */
+/* vim: set ft=javascript ts=2 et sw=2 tw=80: */
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+const data = new Map();
+
+const datafiles = [
+  "console-log"
+];
+
+datafiles.forEach(function(file) {
+  const filepath = `./${file}`;
+  data.set(file, require(filepath));
+});
+
+module.exports = data;

--- a/devtools/client/webconsole/webconsole.js
+++ b/devtools/client/webconsole/webconsole.js
@@ -1270,12 +1270,8 @@ WebConsoleFrame.prototype = {
       case "exception":
       case "assert":
       case "debug": {
-        if (this.SUPER_FRONTEND_EXPERIMENT) {
-          this.newConsoleOutput.dispatchMessageAdd(message);
-        } else {
-          let msg = new Messages.ConsoleGeneric(message);
-          node = msg.init(this.output).render().element;
-        }
+        let msg = new Messages.ConsoleGeneric(message);
+        node = msg.init(this.output).render().element;
         break;
       }
       case "table": {
@@ -3359,7 +3355,11 @@ WebConsoleConnectionProxy.prototype = {
    */
   _onConsoleAPICall: function(type, packet) {
     if (this.webConsoleFrame && packet.from == this._consoleActor) {
-      this.webConsoleFrame.handleConsoleAPICall(packet.message);
+      if (this.webConsoleFrame.SUPER_FRONTEND_EXPERIMENT) {
+        this.webConsoleFrame.newConsoleOutput.dispatchMessageAdd(packet);
+      } else {
+        this.webConsoleFrame.handleConsoleAPICall(packet.message);
+      }
     }
   },
 


### PR DESCRIPTION
r?

This fills in a lot of the testing strategy. For now, I'm not attempting to run it in the mochitest, but it should be pretty easy to wire them up after we get that committed to tree. I use jsdom to test the DOM stuff. Once we have the mochitests running, we can hide this in the `if(process)` block.

LMK if you have any thoughts/concerns about the testing. I think that most of the different testing strategies we'll need are in place now. If these testing strategies sound good to you, I think the rest will be pretty straightforward TDD development.

Also, there's still some ambiguity between message and packet here. I changed some to clarify that we're actually passing around the packet, not the message that is nested inside it. I need to do another pass and make it all consistent. I'm thinking of standardizing on messagePackets, but lmk if you disagree.
