### PR TITLE
Make it possible to test components with query path

### DIFF
--- a/devtools/client/webconsole/new-console-output/test/components/test_console-api-call.html
+++ b/devtools/client/webconsole/new-console-output/test/components/test_console-api-call.html
@@ -13,31 +13,20 @@
 
 <script type="text/javascript;version=1.8">
 window.onload = Task.async(function* () {
-  var { BrowserLoader } = Components.utils.import(
+  const { BrowserLoader } = Components.utils.import(
     "resource://devtools/client/shared/browser-loader.js", {});
-  var rootUrl = "resource://devtools/client/shared/components/";
-  var require = BrowserLoader({
+  const rootUrl = "resource://devtools/client/shared/components/";
+  const require = BrowserLoader({
     baseURI: rootUrl,
     window: this}).require;
 
-  var { ConsoleApiCall } = browserRequire("devtools/client/webconsole/new-console-output/components/message-types/console-api-call");
+  const { ConsoleApiCall } = browserRequire("devtools/client/webconsole/new-console-output/components/message-types/console-api-call");
 
-  yield testComponentWithRDP({
-    command: {
-      type: "console",
-      string: "console.log('foobar', 'test')"
-    },
-    component: ConsoleApiCall,
-    expectedHTML: `
-    <span>
-      <span class="message-flex-body">
-        <span class="message-body devtools-monospace">
-          <span class="console-string">foobar test</span>
-        </span>
-      </span>
-    </span>
-    `
-  });
+  const packet = yield getPacket("console.log('foobar', 'test')", "consoleAPICall");
+  const rendered = renderComponent(ConsoleApiCall, {packet});
+  
+  const queryPath = "span span.message-flex-body span.message-body.devtools-monospace span.console-string";
+  is(1, rendered.querySelectorAll(queryPath).length, "ConsoleApiCall component produces expected DOM")
 
   SimpleTest.finish()
 });


### PR DESCRIPTION
This is just to demo the difference.

If we go this way, I'll probably break up the testComponentWithRDP function into a couple of different functions... 1 that gets the packet, one that gets the rendered dom, and then perform the query path test directly in the test function.
