### PR TITLE
Change message structure to include metadata

### DIFF
--- a/devtools/client/webconsole/new-console-output/actions/messages.js
+++ b/devtools/client/webconsole/new-console-output/actions/messages.js
@@ -5,20 +5,50 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 
-const {
-  MESSAGE_ADD,
-  MESSAGES_CLEAR
-} = require("../constants");
+const constants = require("../constants");
 
-exports.messageAdd = function messageAdd(packet) {
+function messageAdd(packet) {
+  let message = prepareMessage(packet);
   return {
-    type: MESSAGE_ADD,
-    packet: packet
+    type: constants.MESSAGE_ADD,
+    message
   };
-};
+}
 
-exports.messagesClear = function messagesClear() {
+function messagesClear() {
   return {
-    type: MESSAGES_CLEAR
+    type: constants.MESSAGES_CLEAR
   };
-};
+}
+
+function prepareMessage(packet) {
+  let allowRepeating;
+  let category;
+  let data;
+  let messageType;
+  let severity;
+
+  const level = constants.LEVELS[packet.message.level];
+  switch (packet.type) {
+    case "consoleAPICall":
+      allowRepeating = true;
+      category = "console";
+      data = packet.message;
+      messageType = "ConsoleApiCall";
+      severity = constants.SEVERITY_CLASS_FRAGMENTS[level];
+      break;
+  }
+
+  return {
+    allowRepeating,
+    category,
+    data,
+    messageType,
+    severity
+  };
+}
+
+exports.messageAdd = messageAdd;
+exports.messagesClear = messagesClear;
+// Export for use in testing.
+exports.prepareMessage = prepareMessage;

--- a/devtools/client/webconsole/new-console-output/actions/messages.js
+++ b/devtools/client/webconsole/new-console-output/actions/messages.js
@@ -33,7 +33,7 @@ function prepareMessage(packet) {
     case "consoleAPICall":
       allowRepeating = true;
       category = "console";
-      data = packet.message;
+      data = Object.assign({}, packet.message);
       messageType = "ConsoleApiCall";
       severity = constants.SEVERITY_CLASS_FRAGMENTS[level];
       break;

--- a/devtools/client/webconsole/new-console-output/actions/messages.js
+++ b/devtools/client/webconsole/new-console-output/actions/messages.js
@@ -5,19 +5,24 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 
-const constants = require("../constants");
+const {
+  MESSAGE_ADD,
+  MESSAGES_CLEAR,
+  LEVELS,
+  SEVERITY_CLASS_FRAGMENTS
+} = require("../constants");
 
 function messageAdd(packet) {
   let message = prepareMessage(packet);
   return {
-    type: constants.MESSAGE_ADD,
+    type: MESSAGE_ADD,
     message
   };
 }
 
 function messagesClear() {
   return {
-    type: constants.MESSAGES_CLEAR
+    type: MESSAGES_CLEAR
   };
 }
 
@@ -28,14 +33,13 @@ function prepareMessage(packet) {
   let messageType;
   let severity;
 
-  const level = constants.LEVELS[packet.message.level];
   switch (packet.type) {
     case "consoleAPICall":
       allowRepeating = true;
       category = "console";
       data = Object.assign({}, packet.message);
       messageType = "ConsoleApiCall";
-      severity = constants.SEVERITY_CLASS_FRAGMENTS[level];
+      severity = SEVERITY_CLASS_FRAGMENTS[LEVELS[packet.message.level]];
       break;
   }
 

--- a/devtools/client/webconsole/new-console-output/components/console-output.js
+++ b/devtools/client/webconsole/new-console-output/components/console-output.js
@@ -13,9 +13,9 @@ const ConsoleOutput = React.createClass({
   displayName: "ConsoleOutput",
 
   render() {
-    let messageNodes = this.props.messagePackets.map(function(packet) {
+    let messageNodes = this.props.messages.map(function(message) {
       return (
-        MessageContainer({ packet })
+        MessageContainer({ message })
       );
     });
     return (
@@ -26,7 +26,7 @@ const ConsoleOutput = React.createClass({
 
 const mapStateToProps = (state) => {
   return {
-    messagePackets: state.messages
+    messages: state.messages
   };
 };
 

--- a/devtools/client/webconsole/new-console-output/components/message-container.js
+++ b/devtools/client/webconsole/new-console-output/components/message-container.js
@@ -18,19 +18,20 @@ const MessageContainer = createClass({
   displayName: "MessageContainer",
 
   propTypes: {
-    packet: PropTypes.object.isRequired,
+    message: PropTypes.object.isRequired,
   },
 
   render() {
-    let MessageComponent = getMessageComponent(this.props.packet);
-    return createElement(MessageComponent, { packet: this.props.packet });
+    debugger
+    let MessageComponent = getMessageComponent(this.props.message.messageType);
+    return createElement(MessageComponent, { message: this.props.message });
   }
 });
 
-function getMessageComponent(packet) {
+function getMessageComponent(messageType) {
   let MessageComponent;
-  switch (packet.type) {
-    case "consoleAPICall":
+  switch (messageType) {
+    case "ConsoleApiCall":
       MessageComponent = require("devtools/client/webconsole/new-console-output/components/message-types/console-api-call").ConsoleApiCall;
       break;
   }

--- a/devtools/client/webconsole/new-console-output/components/message-types/console-api-call.js
+++ b/devtools/client/webconsole/new-console-output/components/message-types/console-api-call.js
@@ -17,16 +17,16 @@ const ConsoleApiCall = createClass({
   displayName: "ConsoleApiCall",
 
   propTypes: {
-    packet: PropTypes.object.isRequired,
+    message: PropTypes.object.isRequired,
   },
 
   render() {
-    const { message } = this.props.packet;
+    const { data } = this.props.message;
     return dom.span({className: "message-body-wrapper"},
       dom.span({},
         dom.span({className: "message-flex-body"},
           dom.span({className: "message-body devtools-monospace"},
-            dom.span({className: "console-string"}, message.arguments.join(" "))
+            dom.span({className: "console-string"}, data.arguments.join(" "))
           )
         )
       )

--- a/devtools/client/webconsole/new-console-output/constants.js
+++ b/devtools/client/webconsole/new-console-output/constants.js
@@ -5,5 +5,72 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 
-exports.MESSAGE_ADD = "MESSAGE_ADD";
-exports.MESSAGES_CLEAR = "MESSAGES_CLEAR";
+const actionTypes = {
+  MESSAGE_ADD: "MESSAGE_ADD",
+  MESSAGES_CLEAR: "MESSAGES_CLEAR",
+};
+
+const categories = {
+  CATEGORY_NETWORK: 0,
+  CATEGORY_CSS: 1,
+  CATEGORY_JS: 2,
+  CATEGORY_WEBDEV: 3,
+  CATEGORY_INPUT: 4,
+  CATEGORY_OUTPUT: 5,
+  CATEGORY_SECURITY: 6,
+  CATEGORY_SERVER: 7
+};
+
+const severities = {
+  SEVERITY_ERROR: 0,
+  SEVERITY_WARNING: 1,
+  SEVERITY_INFO: 2,
+  SEVERITY_LOG: 3
+};
+
+// The fragment of a CSS class name that identifies categories/severities.
+const fragments = {
+  CATEGORY_CLASS_FRAGMENTS: [
+    "network",
+    "cssparser",
+    "exception",
+    "console",
+    "input",
+    "output",
+    "security",
+    "server",
+  ],
+  SEVERITY_CLASS_FRAGMENTS: [
+    "error",
+    "warn",
+    "info",
+    "log",
+  ]
+};
+
+// A mapping from the console API log event levels to the Web Console
+// severities.
+const levels = {
+  LEVELS: {
+    error: severities.SEVERITY_ERROR,
+    exception: severities.SEVERITY_ERROR,
+    assert: severities.SEVERITY_ERROR,
+    warn: severities.SEVERITY_WARNING,
+    info: severities.SEVERITY_INFO,
+    log: severities.SEVERITY_LOG,
+    trace: severities.SEVERITY_LOG,
+    table: severities.SEVERITY_LOG,
+    debug: severities.SEVERITY_LOG,
+    dir: severities.SEVERITY_LOG,
+    dirxml: severities.SEVERITY_LOG,
+    group: severities.SEVERITY_LOG,
+    groupCollapsed: severities.SEVERITY_LOG,
+    groupEnd: severities.SEVERITY_LOG,
+    time: severities.SEVERITY_LOG,
+    timeEnd: severities.SEVERITY_LOG,
+    count: severities.SEVERITY_LOG
+  }
+};
+
+// Combine into a single constants object
+module.exports = Object.assign({}, actionTypes, categories, severities, fragments, levels);

--- a/devtools/client/webconsole/new-console-output/reducers/messages.js
+++ b/devtools/client/webconsole/new-console-output/reducers/messages.js
@@ -12,7 +12,7 @@ const constants = require("devtools/client/webconsole/new-console-output/constan
 function messages(state = [], action) {
   switch (action.type) {
     case constants.MESSAGE_ADD:
-      return state.concat([action.packet]);
+      return state.concat([action.message]);
     case constants.MESSAGES_CLEAR:
       return [];
   }

--- a/devtools/client/webconsole/new-console-output/test/actions/head.js
+++ b/devtools/client/webconsole/new-console-output/test/actions/head.js
@@ -10,3 +10,29 @@ var DevToolsUtils = require("devtools/shared/DevToolsUtils");
 DevToolsUtils.testing = true;
 DevToolsUtils.dumpn.wantLogging = true;
 DevToolsUtils.dumpv.wantVerbose = false;
+
+// @TODO consolidate once we have a shared head. See #16
+const testPackets = new Map();
+testPackets.set("console.log", {
+  "from": "server1.conn4.child1/consoleActor2",
+  "type": "consoleAPICall",
+  "message": {
+    "arguments": [
+      "foobar",
+      "test"
+    ],
+    "columnNumber": 1,
+    "counter": null,
+    "filename": "file:///test.html",
+    "functionName": "",
+    "groupName": "",
+    "level": "log",
+    "lineNumber": 1,
+    "private": false,
+    "styles": [],
+    "timeStamp": 1455064271115,
+    "timer": null,
+    "workerType": "none",
+    "category": "webdev"
+  }
+});

--- a/devtools/client/webconsole/new-console-output/test/actions/test_messages.js
+++ b/devtools/client/webconsole/new-console-output/test/actions/test_messages.js
@@ -10,11 +10,17 @@ function run_test() {
 }
 
 add_task(function*() {
-  const packet = {};
+  const packet = testPackets.get("console.log");
   const action = actions.messageAdd(packet);
   const expected = {
     type: constants.MESSAGE_ADD,
-    packet: {}
+    message: {
+      allowRepeating: true,
+      category: "console",
+      data: packet.message,
+      messageType: "ConsoleApiCall",
+      severity: "log"
+    }
   };
   deepEqual(action, expected,
     "messageAdd action creator returns expected action object");

--- a/devtools/client/webconsole/new-console-output/test/components/test_console-api-call.html
+++ b/devtools/client/webconsole/new-console-output/test/components/test_console-api-call.html
@@ -20,11 +20,14 @@ window.onload = Task.async(function* () {
     baseURI: rootUrl,
     window: this}).require;
 
+  const { prepareMessage } = require("devtools/client/webconsole/new-console-output/actions/messages");
+
   const { ConsoleApiCall } = browserRequire("devtools/client/webconsole/new-console-output/components/message-types/console-api-call");
 
   const packet = yield getPacket("console.log('foobar', 'test')", "consoleAPICall");
-  const rendered = renderComponent(ConsoleApiCall, {packet});
-  
+  const message = prepareMessage(packet);
+  const rendered = renderComponent(ConsoleApiCall, {message});
+
   const queryPath = "span span.message-flex-body span.message-body.devtools-monospace span.console-string";
   is(1, rendered.querySelectorAll(queryPath).length, "ConsoleApiCall component produces expected DOM")
 

--- a/devtools/client/webconsole/new-console-output/test/components/test_message-container-utils.js
+++ b/devtools/client/webconsole/new-console-output/test/components/test_message-container-utils.js
@@ -9,8 +9,7 @@ function run_test() {
 add_task(function*() {
   const { getMessageComponent } = require("devtools/client/webconsole/new-console-output/components/message-container");
   const { ConsoleApiCall } = require("devtools/client/webconsole/new-console-output/components/message-types/console-api-call");
-  const packet = testPackets.get("console.log");
-  const result = getMessageComponent(packet);
+  const result = getMessageComponent("ConsoleApiCall");
   equal(result, ConsoleApiCall,
     "getMessageComponent() returns correct component for console.log");
 });

--- a/devtools/client/webconsole/new-console-output/test/components/test_message-container.html
+++ b/devtools/client/webconsole/new-console-output/test/components/test_message-container.html
@@ -19,14 +19,17 @@ window.onload = Task.async(function* () {
   const require = BrowserLoader({
     baseURI: rootUrl,
     window: this}).require;
-  
+
   const React = browserRequire("devtools/client/shared/vendor/react");
   const TestUtils = React.addons.TestUtils;
+  const { prepareMessage } = require("devtools/client/webconsole/new-console-output/actions/messages");
+
   const { MessageContainer } = browserRequire("devtools/client/webconsole/new-console-output/components/message-container");
   const { ConsoleApiCall } = browserRequire("devtools/client/webconsole/new-console-output/components/message-types/console-api-call");
 
   const packet = yield getPacket("console.log('foobar', 'test')", "consoleAPICall");
-  const el = React.createElement(MessageContainer, { packet });
+  const message = prepareMessage(packet);
+  const el = React.createElement(MessageContainer, { message });
   const renderer = TestUtils.createRenderer();
   renderer.render(el, {});
   const result = renderer.getRenderOutput();

--- a/devtools/client/webconsole/new-console-output/test/store/test_messages.js
+++ b/devtools/client/webconsole/new-console-output/test/store/test_messages.js
@@ -4,16 +4,22 @@
 
 const actions = require("devtools/client/webconsole/new-console-output/actions/messages");
 const packet = testPackets.get("console.log");
+const { prepareMessage } = require("devtools/client/webconsole/new-console-output/actions/messages");
 
 function run_test() {
   run_next_test();
 }
 
+/**
+ * Test adding a message to the store.
+ */
 add_task(function*() {
   const { getState, dispatch } = storeFactory();
 
   dispatch(actions.messageAdd(packet));
-  const expectedPacket = Object.assign({}, packet);
-  deepEqual(getState().messages, [expectedPacket],
+
+  const expectedMessage = prepareMessage(packet);
+
+  deepEqual(getState().messages, [expectedMessage],
     "MESSAGE_ADD action adds a message");
 });


### PR DESCRIPTION
We need to include metadata for things like repeating. In contrast to the way we did it in the experiment, this code adds the metadata outside of the message object (which I'm calling the message data). This means we don't have the potential for data clobbering.

This adds a `prepareMessage()` function (similar to what was a util in the experiment). I went back and forth between putting it in the reducer or action creator, but decided on the AC. For my own future reference, here are two discussions I found helpful [[1]](https://github.com/reactjs/redux/issues/1454#issuecomment-189861346) [[2]](http://stackoverflow.com/a/34135166).
