### PR TITLE
Fix console.log() HTML structure

### DIFF
--- a/devtools/client/webconsole/new-console-output/components/message-types/console-api-call.js
+++ b/devtools/client/webconsole/new-console-output/components/message-types/console-api-call.js
@@ -8,30 +8,42 @@
 
 // React & Redux
 const {
-  createClass,
+  createElement,
   DOM: dom,
   PropTypes
 } = require("devtools/client/shared/vendor/react");
 
-const ConsoleApiCall = createClass({
-  displayName: "ConsoleApiCall",
+ConsoleApiCall.displayName = "ConsoleApiCall";
 
-  propTypes: {
-    message: PropTypes.object.isRequired,
-  },
+ConsoleApiCall.propTypes = {
+  message: PropTypes.object.isRequired,
+};
 
-  render() {
-    const { data } = this.props.message;
-    return dom.span({className: "message-body-wrapper"},
-      dom.span({},
-        dom.span({className: "message-flex-body"},
-          dom.span({className: "message-body devtools-monospace"},
-            dom.span({className: "console-string"}, data.arguments.join(" "))
-          )
-        )
+function ConsoleApiCall(props) {
+  const messageBody =
+    dom.span({className: "message-body devtools-monospace"},
+      formatTextContent(props.message.data.arguments));
+  const children = [
+    messageBody
+  ];
+
+  return dom.span({className: "message-body-wrapper"},
+    dom.span({},
+      dom.span({className: "message-flex-body"},
+        children
       )
-    );
-  }
-});
+    )
+  );
+}
+
+function formatTextContent(args) {
+  return args.map(function(arg, i, arr) {
+    const str = dom.span({className: "console-string"}, arg);
+    if (i < arr.length - 1) {
+      return [str, " "];
+    }
+    return str;
+  });
+}
 
 module.exports.ConsoleApiCall = ConsoleApiCall;

--- a/devtools/client/webconsole/new-console-output/test/components/head.js
+++ b/devtools/client/webconsole/new-console-output/test/components/head.js
@@ -61,8 +61,12 @@ function* getPacket(command, type = "evaluationResult") {
 
 function renderComponent(component, props) {
   const el = React.createElement(component, props, {});
-  const renderedComponent = TestUtils.renderIntoDocument(el);
-  return ReactDOM.findDOMNode(renderedComponent);
+  // By default, renderIntoDocument() won't work for stateless components, but
+  // it will work if the stateless component is wrapped in a stateful one.
+  // See https://github.com/facebook/react/issues/4839
+  const wrappedEl = React.DOM.span({}, [el]);
+  const renderedComponent = TestUtils.renderIntoDocument(wrappedEl);
+  return ReactDOM.findDOMNode(renderedComponent).children[0];
 }
 
 function cleanActualHTML(htmlString) {

--- a/devtools/client/webconsole/new-console-output/test/components/test_console-api-call.html
+++ b/devtools/client/webconsole/new-console-output/test/components/test_console-api-call.html
@@ -28,8 +28,11 @@ window.onload = Task.async(function* () {
   const message = prepareMessage(packet);
   const rendered = renderComponent(ConsoleApiCall, {message});
 
-  const queryPath = "span span.message-flex-body span.message-body.devtools-monospace span.console-string";
-  is(1, rendered.querySelectorAll(queryPath).length, "ConsoleApiCall component produces expected DOM")
+  const queryPath = "span span.message-flex-body span.message-body.devtools-monospace";
+  const messageBody = rendered.querySelectorAll(queryPath);
+  const consoleStringNodes = messageBody[0].querySelectorAll("span.console-string");
+  is(2, consoleStringNodes.length, "ConsoleApiCall outputs expected HTML structure");
+  is(messageBody[0].textContent, "foobar test", "ConsoleApiCall outputs expected text");
 
   SimpleTest.finish()
 });


### PR DESCRIPTION
In the expectedHTML test data I was using before, I hadn't passed in two arguments. This is updated to properly output multiple arguments.

I also changed it to a stateless function component.
