### PR TITLE
Handle repeating messages. r=bgrins

### DIFF
--- a/devtools/client/webconsole/new-console-output/actions/messages.js
+++ b/devtools/client/webconsole/new-console-output/actions/messages.js
@@ -3,13 +3,16 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 "use strict";
+
+const {
+  prepareMessage
+} = require("devtools/client/webconsole/new-console-output/utils/messages");
 
 const {
   MESSAGE_ADD,
   MESSAGES_CLEAR,
-  LEVELS,
-  SEVERITY_CLASS_FRAGMENTS
 } = require("../constants");
 
 function messageAdd(packet) {
@@ -26,33 +29,5 @@ function messagesClear() {
   };
 }
 
-function prepareMessage(packet) {
-  let allowRepeating;
-  let category;
-  let data;
-  let messageType;
-  let severity;
-
-  switch (packet.type) {
-    case "consoleAPICall":
-      allowRepeating = true;
-      category = "console";
-      data = Object.assign({}, packet.message);
-      messageType = "ConsoleApiCall";
-      severity = SEVERITY_CLASS_FRAGMENTS[LEVELS[packet.message.level]];
-      break;
-  }
-
-  return {
-    allowRepeating,
-    category,
-    data,
-    messageType,
-    severity
-  };
-}
-
 exports.messageAdd = messageAdd;
 exports.messagesClear = messagesClear;
-// Export for use in testing.
-exports.prepareMessage = prepareMessage;

--- a/devtools/client/webconsole/new-console-output/components/message-repeat.js
+++ b/devtools/client/webconsole/new-console-output/components/message-repeat.js
@@ -1,0 +1,28 @@
+
+/* -*- indent-tabs-mode: nil; js-indent-level: 2 -*- */
+/* vim: set ft=javascript ts=2 et sw=2 tw=80: */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+// React & Redux
+const {
+  DOM: dom,
+  PropTypes
+} = require("devtools/client/shared/vendor/react");
+
+MessageRepeat.displayName = "MessageRepeat";
+
+MessageRepeat.propTypes = {
+  repeat: PropTypes.number.isRequired
+};
+
+function MessageRepeat(props) {
+  const { repeat } = props;
+  const visibility = repeat > 1 ? "visible" : "hidden";
+  return dom.span({className: "message-repeats", style: {visibility}}, repeat);
+}
+
+exports.MessageRepeat = MessageRepeat;

--- a/devtools/client/webconsole/new-console-output/components/message-types/console-api-call.js
+++ b/devtools/client/webconsole/new-console-output/components/message-types/console-api-call.js
@@ -12,6 +12,7 @@ const {
   DOM: dom,
   PropTypes
 } = require("devtools/client/shared/vendor/react");
+const { MessageRepeat } = require("devtools/client/webconsole/new-console-output/components/message-repeat");
 
 ConsoleApiCall.displayName = "ConsoleApiCall";
 
@@ -20,11 +21,14 @@ ConsoleApiCall.propTypes = {
 };
 
 function ConsoleApiCall(props) {
+  const { message } = props;
   const messageBody =
     dom.span({className: "message-body devtools-monospace"},
-      formatTextContent(props.message.data.arguments));
+      formatTextContent(message.data.arguments));
+  const repeat = createElement(MessageRepeat, {repeat: message.repeat});
   const children = [
-    messageBody
+    messageBody,
+    repeat
   ];
 
   return dom.span({className: "message-body-wrapper"},

--- a/devtools/client/webconsole/new-console-output/components/moz.build
+++ b/devtools/client/webconsole/new-console-output/components/moz.build
@@ -9,5 +9,6 @@ DIRS += [
 
 DevToolsModules(
     'console-output.js',
-    'message-container.js'
+    'message-container.js',
+    'message-repeat.js'
 )

--- a/devtools/client/webconsole/new-console-output/moz.build
+++ b/devtools/client/webconsole/new-console-output/moz.build
@@ -7,6 +7,7 @@ DIRS += [
     'actions',
     'components',
     'reducers',
+    'utils',
 ]
 
 DevToolsModules(

--- a/devtools/client/webconsole/new-console-output/reducers/messages.js
+++ b/devtools/client/webconsole/new-console-output/reducers/messages.js
@@ -13,7 +13,15 @@ const constants = require("devtools/client/webconsole/new-console-output/constan
 function messages(state = [], action) {
   switch (action.type) {
     case constants.MESSAGE_ADD:
-      return state.concat([action.message]);
+      let newMessage = action.message;
+      if (newMessage.allowRepeating && state.length > 0) {
+        let lastMessage = state[state.length - 1];
+        if (lastMessage.repeatId === newMessage.repeatId) {
+          newMessage.repeat = lastMessage.repeat + 1;
+          return state.slice(0, state.length-1).concat(newMessage);
+        }
+      }
+      return state.concat([ newMessage ]);
     case constants.MESSAGES_CLEAR:
       return [];
   }

--- a/devtools/client/webconsole/new-console-output/reducers/messages.js
+++ b/devtools/client/webconsole/new-console-output/reducers/messages.js
@@ -7,6 +7,7 @@
 
 const Immutable = require("devtools/client/shared/vendor/immutable");
 
+const { getRepeatId } = require("devtools/client/webconsole/new-console-output/utils/messages");
 const constants = require("devtools/client/webconsole/new-console-output/constants");
 
 function messages(state = [], action) {

--- a/devtools/client/webconsole/new-console-output/store.js
+++ b/devtools/client/webconsole/new-console-output/store.js
@@ -3,8 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 
-const { combineReducers } = require("devtools/client/shared/vendor/redux");
-const createStore = require("devtools/client/shared/redux/create-store")();
+const { combineReducers, createStore } = require("devtools/client/shared/vendor/redux");
 const { reducers } = require("./reducers/index");
 
 function storeFactory(initialState = {}) {

--- a/devtools/client/webconsole/new-console-output/test/actions/test_messages.js
+++ b/devtools/client/webconsole/new-console-output/test/actions/test_messages.js
@@ -2,7 +2,14 @@
    http://creativecommons.org/publicdomain/zero/1.0/ */
 "use strict";
 
-const actions = require("devtools/client/webconsole/new-console-output/actions/messages");
+const {
+  messageAdd,
+  messagesClear
+} = require("devtools/client/webconsole/new-console-output/actions/messages");
+const {
+  prepareMessage,
+  getRepeatId
+} = require("devtools/client/webconsole/new-console-output/utils/messages");
 const constants = require("devtools/client/webconsole/new-console-output/constants");
 
 function run_test() {
@@ -11,7 +18,7 @@ function run_test() {
 
 add_task(function*() {
   const packet = testPackets.get("console.log");
-  const action = actions.messageAdd(packet);
+  const action = messageAdd(packet);
   const expected = {
     type: constants.MESSAGE_ADD,
     message: {
@@ -19,6 +26,8 @@ add_task(function*() {
       category: "console",
       data: packet.message,
       messageType: "ConsoleApiCall",
+      repeat: 1,
+      repeatId: getRepeatId(packet.message),
       severity: "log"
     }
   };
@@ -27,7 +36,7 @@ add_task(function*() {
 });
 
 add_task(function*() {
-  const action = actions.messagesClear();
+  const action = messagesClear();
   const expected = {
     type: constants.MESSAGES_CLEAR,
   };

--- a/devtools/client/webconsole/new-console-output/test/components/chrome.ini
+++ b/devtools/client/webconsole/new-console-output/test/components/chrome.ini
@@ -4,4 +4,6 @@ support-files =
   head.js
 
 [test_console-api-call.html]
+[test_console-api-call_repeat.html]
 [test_message-container.html]
+[test_message-repeat.html]

--- a/devtools/client/webconsole/new-console-output/test/components/test_console-api-call.html
+++ b/devtools/client/webconsole/new-console-output/test/components/test_console-api-call.html
@@ -13,7 +13,7 @@
 
 <script type="text/javascript;version=1.8">
 window.onload = Task.async(function* () {
-  const { prepareMessage } = require("devtools/client/webconsole/new-console-output/actions/messages");
+  const { prepareMessage } = require("devtools/client/webconsole/new-console-output/utils/messages");
   const { ConsoleApiCall } = require("devtools/client/webconsole/new-console-output/components/message-types/console-api-call");
 
   const packet = yield getPacket("console.log('foobar', 'test')", "consoleAPICall");
@@ -23,7 +23,7 @@ window.onload = Task.async(function* () {
   const queryPath = "span span.message-flex-body span.message-body.devtools-monospace";
   const messageBody = rendered.querySelectorAll(queryPath);
   const consoleStringNodes = messageBody[0].querySelectorAll("span.console-string");
-  is(2, consoleStringNodes.length, "ConsoleApiCall outputs expected HTML structure");
+  is(consoleStringNodes.length, 2, "ConsoleApiCall outputs expected HTML structure");
   is(messageBody[0].textContent, "foobar test", "ConsoleApiCall outputs expected text");
 
   SimpleTest.finish()

--- a/devtools/client/webconsole/new-console-output/test/components/test_console-api-call_repeat.html
+++ b/devtools/client/webconsole/new-console-output/test/components/test_console-api-call_repeat.html
@@ -1,0 +1,36 @@
+<!DOCTYPE HTML>
+<html lang="en">
+<head>
+  <meta charset="utf8">
+  <title>Test for ConsoleApiCall component with repeats</title>
+  <script type="text/javascript" src="chrome://mochikit/content/tests/SimpleTest/SimpleTest.js"></script>
+  <script type="application/javascript;version=1.8" src="head.js"></script>
+  <!-- Any copyright is dedicated to the Public Domain.
+     - http://creativecommons.org/publicdomain/zero/1.0/ -->
+</head>
+<body>
+<p>Test for ConsoleApiCall component with repeats</p>
+
+<script type="text/javascript;version=1.8">
+window.onload = Task.async(function* () {
+  const { prepareMessage } = require("devtools/client/webconsole/new-console-output/utils/messages");
+  const { ConsoleApiCall } = require("devtools/client/webconsole/new-console-output/components/message-types/console-api-call");
+
+  const packet = yield getPacket("console.log('foobar', 'test')", "consoleAPICall");
+  const message = prepareMessage(packet);
+  message.repeat = 107;
+  const rendered = renderComponent(ConsoleApiCall, {message});
+
+  const messageBodyPath = "span > span.message-flex-body > span.message-body.devtools-monospace";
+  const messageBody = rendered.querySelectorAll(messageBodyPath);
+  is(messageBody[0].textContent, "foobar test", "ConsoleApiCall outputs expected text for repeated message");
+
+  const repeatPath = "span > span.message-flex-body > span.message-body.devtools-monospace + span.message-repeats";
+  const repeat = rendered.querySelectorAll(repeatPath);
+  is(repeat[0].textContent, `${message.repeat}`, "ConsoleApiCall outputs correct repeat count");
+
+  SimpleTest.finish()
+});
+</script>
+</body>
+</html>

--- a/devtools/client/webconsole/new-console-output/test/components/test_message-container.html
+++ b/devtools/client/webconsole/new-console-output/test/components/test_message-container.html
@@ -15,7 +15,7 @@
 window.onload = Task.async(function* () {
   const React = require("devtools/client/shared/vendor/react");
   const TestUtils = React.addons.TestUtils;
-  const { prepareMessage } = require("devtools/client/webconsole/new-console-output/actions/messages");
+  const { prepareMessage } = require("devtools/client/webconsole/new-console-output/utils/messages");
 
   const { MessageContainer } = require("devtools/client/webconsole/new-console-output/components/message-container");
   const { ConsoleApiCall } = require("devtools/client/webconsole/new-console-output/components/message-types/console-api-call");

--- a/devtools/client/webconsole/new-console-output/test/components/test_message-repeat.html
+++ b/devtools/client/webconsole/new-console-output/test/components/test_message-repeat.html
@@ -1,0 +1,31 @@
+<!DOCTYPE HTML>
+<html lang="en">
+<head>
+  <meta charset="utf8">
+  <title>Test for MessageRepeat component</title>
+  <script type="text/javascript" src="chrome://mochikit/content/tests/SimpleTest/SimpleTest.js"></script>
+  <script type="application/javascript;version=1.8" src="head.js"></script>
+  <!-- Any copyright is dedicated to the Public Domain.
+     - http://creativecommons.org/publicdomain/zero/1.0/ -->
+</head>
+<body>
+<p>Test for MessageRepeat component</p>
+
+<script type="text/javascript;version=1.8">
+window.onload = Task.async(function* () {
+  const { MessageRepeat } = require("devtools/client/webconsole/new-console-output/components/message-repeat");
+
+  const repeatRendered = renderComponent(MessageRepeat, { repeat: 99 });
+  ok(repeatRendered.classList.contains("message-repeats"), "MessageRepeat has expected class");
+  is(repeatRendered.style.visibility, "visible", "MessageRepeat with 2+ repeats is visible");
+  is(repeatRendered.textContent, "99", "MessageRepeat shows correct number of repeats");
+
+  const noRepeatRendered = renderComponent(MessageRepeat, { repeat: 1 });
+  is(noRepeatRendered.style.visibility, "hidden", "MessageRepeat with 1 repeat is hidden");
+  is(noRepeatRendered.textContent, "1", "MessageRepeat with 1 repeat shows correct number of repeats")
+
+  SimpleTest.finish();
+});
+</script>
+</body>
+</html>

--- a/devtools/client/webconsole/new-console-output/test/store/test_messages.js
+++ b/devtools/client/webconsole/new-console-output/test/store/test_messages.js
@@ -26,3 +26,34 @@ add_task(function*() {
   deepEqual(getState().messages, [expectedMessage],
     "MESSAGE_ADD action adds a message");
 });
+
+/**
+ * Test repeating messages in the store.
+ */
+add_task(function*() {
+  const { getState, dispatch } = storeFactory();
+
+  dispatch(actions.messageAdd(packet));
+  dispatch(actions.messageAdd(packet));
+  dispatch(actions.messageAdd(packet));
+
+  const expectedMessage = prepareMessage(packet);
+  expectedMessage.repeat = 3;
+
+  deepEqual(getState().messages, [expectedMessage],
+    "Adding same message to the store twice results in repeated message");
+});
+
+/**
+ * Test getRepeatId().
+ */
+add_task(function*() {
+  const message1 = prepareMessage(packet);
+  const message2 = prepareMessage(packet);
+  equal(getRepeatId(message1), getRepeatId(message2),
+    "getRepeatId() returns same repeat id for objects with the same values");
+
+  message2.data.arguments = ["new args"];
+  notEqual(getRepeatId(message1), getRepeatId(message2),
+    "getRepeatId() returns different repeat ids for different values");
+});

--- a/devtools/client/webconsole/new-console-output/test/store/test_messages.js
+++ b/devtools/client/webconsole/new-console-output/test/store/test_messages.js
@@ -4,7 +4,10 @@
 
 const actions = require("devtools/client/webconsole/new-console-output/actions/messages");
 const packet = testPackets.get("console.log");
-const { prepareMessage } = require("devtools/client/webconsole/new-console-output/actions/messages");
+const {
+  getRepeatId,
+  prepareMessage
+} = require("devtools/client/webconsole/new-console-output/utils/messages");
 
 function run_test() {
   run_next_test();

--- a/devtools/client/webconsole/new-console-output/utils/messages.js
+++ b/devtools/client/webconsole/new-console-output/utils/messages.js
@@ -1,0 +1,56 @@
+/* -*- indent-tabs-mode: nil; js-indent-level: 2 -*- */
+/* vim: set ft=javascript ts=2 et sw=2 tw=80: */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+const {
+  LEVELS,
+  SEVERITY_CLASS_FRAGMENTS
+} = require("../constants");
+
+function prepareMessage(packet) {
+  // @TODO turn this into an Immutable Record.
+  let allowRepeating;
+  let category;
+  let data;
+  let messageType;
+  let repeat;
+  let repeatId;
+  let severity;
+
+  switch (packet.type) {
+    case "consoleAPICall":
+      allowRepeating = true;
+      category = "console";
+      data = Object.assign({}, packet.message);
+      messageType = "ConsoleApiCall";
+      repeat = 1;
+      repeatId = getRepeatId(packet.message);
+      severity = SEVERITY_CLASS_FRAGMENTS[LEVELS[packet.message.level]];
+      break;
+  }
+
+  return {
+    allowRepeating,
+    category,
+    data,
+    messageType,
+    repeat,
+    repeatId,
+    severity
+  };
+}
+
+function getRepeatId(message) {
+  let clonedMessage = JSON.parse(JSON.stringify(message));
+  delete clonedMessage.timeStamp;
+  delete clonedMessage.uniqueID;
+  return JSON.stringify(clonedMessage);
+}
+
+// Export for use in testing.
+exports.prepareMessage = prepareMessage;
+exports.getRepeatId = getRepeatId;

--- a/devtools/client/webconsole/new-console-output/utils/moz.build
+++ b/devtools/client/webconsole/new-console-output/utils/moz.build
@@ -1,0 +1,8 @@
+# vim: set filetype=python:
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+DevToolsModules(
+    'messages.js',
+)


### PR DESCRIPTION
This diverges from our experiment in a couple of ways:
- In the experiment, we set metadata properties (such as repeats) on the message that came in from the server. In this version, I tuck the data from the server in `message.data`.
- The message object is formatted at action creation time. This includes computing the repeatId. This makes the logic in the reducer simpler.
- Instead of omitting the repeat node if there's only one, it outputs a repeat node for each message. This matches the current console. However, unlike the current console, this PR uses the visibility CSS property to manage visibility instead of the value attribute.

@bgrins I think I'll just merge this in, but please give it a retroactive review when you get a chance (that is, not until you're back from PTO). We can make any changes you think are necessary after the fact.
