### PR TITLE
[WIP] Add EvaluationResult handling (via Date)

### DIFF
--- a/devtools/client/webconsole/jsterm.js
+++ b/devtools/client/webconsole/jsterm.js
@@ -356,31 +356,35 @@ JSTerm.prototype = {
       return;
     }
 
-    let msg = new Messages.JavaScriptEvalOutput(response, errorMessage);
-    this.hud.output.addMessage(msg);
+    if (this.hud.SUPER_FRONTEND_EXPERIMENT) {
+      this.hud.newConsoleOutput.dispatchMessageAdd(response);
+    } else {
+      let msg = new Messages.JavaScriptEvalOutput(response, errorMessage);
+      this.hud.output.addMessage(msg);
 
-    if (callback) {
-      let oldFlushCallback = this.hud._flushCallback;
-      this.hud._flushCallback = () => {
-        callback(msg.element);
-        if (oldFlushCallback) {
-          oldFlushCallback();
-          this.hud._flushCallback = oldFlushCallback;
-          return true;
-        }
+      if (callback) {
+        let oldFlushCallback = this.hud._flushCallback;
+        this.hud._flushCallback = () => {
+          callback(msg.element);
+          if (oldFlushCallback) {
+            oldFlushCallback();
+            this.hud._flushCallback = oldFlushCallback;
+            return true;
+          }
 
-        return false;
-      };
-    }
+          return false;
+        };
+      }
 
-    msg._objectActors = new Set();
+      msg._objectActors = new Set();
 
-    if (WebConsoleUtils.isActorGrip(response.exception)) {
-      msg._objectActors.add(response.exception.actor);
-    }
+      if (WebConsoleUtils.isActorGrip(response.exception)) {
+        msg._objectActors.add(response.exception.actor);
+      }
 
-    if (WebConsoleUtils.isActorGrip(result)) {
-      msg._objectActors.add(result.actor);
+      if (WebConsoleUtils.isActorGrip(result)) {
+        msg._objectActors.add(result.actor);
+      }
     }
   },
 

--- a/devtools/client/webconsole/jsterm.js
+++ b/devtools/client/webconsole/jsterm.js
@@ -358,6 +358,8 @@ JSTerm.prototype = {
 
     if (this.hud.SUPER_FRONTEND_EXPERIMENT) {
       this.hud.newConsoleOutput.dispatchMessageAdd(response);
+
+      // @TODO figure out what to do about the objectActors.
     } else {
       let msg = new Messages.JavaScriptEvalOutput(response, errorMessage);
       this.hud.output.addMessage(msg);

--- a/devtools/client/webconsole/new-console-output/components/message-container.js
+++ b/devtools/client/webconsole/new-console-output/components/message-container.js
@@ -22,7 +22,6 @@ const MessageContainer = createClass({
   },
 
   render() {
-    debugger
     let MessageComponent = getMessageComponent(this.props.message.messageType);
     return createElement(MessageComponent, { message: this.props.message });
   }
@@ -33,6 +32,9 @@ function getMessageComponent(messageType) {
   switch (messageType) {
     case "ConsoleApiCall":
       MessageComponent = require("devtools/client/webconsole/new-console-output/components/message-types/console-api-call").ConsoleApiCall;
+      break;
+    case "EvaluationResult":
+      MessageComponent = require("devtools/client/webconsole/new-console-output/components/message-types/evaluation-result").EvaluationResult;
       break;
   }
   return MessageComponent;

--- a/devtools/client/webconsole/new-console-output/components/message-types/console-api-call.js
+++ b/devtools/client/webconsole/new-console-output/components/message-types/console-api-call.js
@@ -31,10 +31,12 @@ function ConsoleApiCall(props) {
     repeat
   ];
 
-  return dom.span({className: "message-body-wrapper"},
-    dom.span({},
-      dom.span({className: "message-flex-body"},
-        children
+  return dom.div({ className: "message cm-s-mozilla" },
+    dom.span({className: "message-body-wrapper"},
+      dom.span({},
+        dom.span({className: "message-flex-body"},
+          children
+        )
       )
     )
   );

--- a/devtools/client/webconsole/new-console-output/components/message-types/date-preview.js
+++ b/devtools/client/webconsole/new-console-output/components/message-types/date-preview.js
@@ -28,10 +28,12 @@ function DatePreview(props) {
     dom.span({ className: "cm-string-2" }, ` ${dateString}`)
   ];
 
-  return dom.span({ className: "message-body-wrapper message-body devtools-monospace" },
-    dom.span({},
-      dom.span({ className: "class-Date" },
-        textNodes
+  return dom.div({ className: "message cm-s-mozilla" },
+    dom.span({ className: "message-body-wrapper message-body devtools-monospace" },
+      dom.span({},
+        dom.span({ className: "class-Date" },
+          textNodes
+        )
       )
     )
   );

--- a/devtools/client/webconsole/new-console-output/components/message-types/date-preview.js
+++ b/devtools/client/webconsole/new-console-output/components/message-types/date-preview.js
@@ -1,0 +1,40 @@
+/* -*- indent-tabs-mode: nil; js-indent-level: 2 -*- */
+/* vim: set ft=javascript ts=2 et sw=2 tw=80: */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+// React & Redux
+const {
+  DOM: dom,
+  PropTypes
+} = require("devtools/client/shared/vendor/react");
+
+DatePreview.displayName = "DatePreview";
+
+DatePreview.propTypes = {
+  message: PropTypes.object.isRequired,
+};
+
+function DatePreview(props) {
+  const { data } = props;
+  const { preview } = data;
+
+  const dateString = new Date(preview.timestamp).toISOString();
+  const textNodes = [
+    dom.a({ className: "cm-variable", draggable: false, href: "#" }, "Date"),
+    dom.span({ className: "cm-string-2" }, ` ${dateString}`)
+  ];
+
+  return dom.span({ className: "message-body-wrapper message-body devtools-monospace" },
+    dom.span({},
+      dom.span({ className: "class-Date" },
+        textNodes
+      )
+    )
+  );
+}
+
+module.exports.DatePreview = DatePreview;

--- a/devtools/client/webconsole/new-console-output/components/message-types/evaluation-result.js
+++ b/devtools/client/webconsole/new-console-output/components/message-types/evaluation-result.js
@@ -1,0 +1,38 @@
+/* -*- indent-tabs-mode: nil; js-indent-level: 2 -*- */
+/* vim: set ft=javascript ts=2 et sw=2 tw=80: */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+// React & Redux
+const {
+  createElement,
+  DOM: dom,
+  PropTypes
+} = require("devtools/client/shared/vendor/react");
+const { MessageRepeat } = require("devtools/client/webconsole/new-console-output/components/message-repeat");
+
+EvaluationResult.displayName = "EvaluationResult";
+
+EvaluationResult.propTypes = {
+  message: PropTypes.object.isRequired,
+};
+
+function EvaluationResult(props) {
+  const { message } = props;
+  let PreviewComponent = getPreviewComponent(message.data);
+  return createElement(PreviewComponent, { data: message.data });
+}
+
+function getPreviewComponent(data) {
+  if (typeof data.class != "undefined") {
+    switch (data.class) {
+      case "Date":
+        return require("devtools/client/webconsole/new-console-output/components/message-types/date-preview").DatePreview;
+    }
+  }
+}
+
+module.exports.EvaluationResult = EvaluationResult;

--- a/devtools/client/webconsole/new-console-output/components/message-types/moz.build
+++ b/devtools/client/webconsole/new-console-output/components/message-types/moz.build
@@ -6,4 +6,5 @@
 DevToolsModules(
     'console-api-call.js',
     'date-preview.js',
+    'evaluation-result.js',
 )

--- a/devtools/client/webconsole/new-console-output/components/message-types/moz.build
+++ b/devtools/client/webconsole/new-console-output/components/message-types/moz.build
@@ -5,4 +5,5 @@
 
 DevToolsModules(
     'console-api-call.js',
+    'date-preview.js',
 )

--- a/devtools/client/webconsole/new-console-output/test/components/chrome.ini
+++ b/devtools/client/webconsole/new-console-output/test/components/chrome.ini
@@ -6,5 +6,6 @@ support-files =
 [test_console-api-call.html]
 [test_console-api-call_repeat.html]
 [test_date-preview.html]
+[test_evaluation-result.html]
 [test_message-container.html]
 [test_message-repeat.html]

--- a/devtools/client/webconsole/new-console-output/test/components/chrome.ini
+++ b/devtools/client/webconsole/new-console-output/test/components/chrome.ini
@@ -5,5 +5,6 @@ support-files =
 
 [test_console-api-call.html]
 [test_console-api-call_repeat.html]
+[test_date-preview.html]
 [test_message-container.html]
 [test_message-repeat.html]

--- a/devtools/client/webconsole/new-console-output/test/components/head.js
+++ b/devtools/client/webconsole/new-console-output/test/components/head.js
@@ -56,11 +56,10 @@ function* getPacket(command, type = "evaluationResult") {
           eval(`top.${command}`);
         });
         break;
-      case "evaluate":
-        // @TODO support JavaScriptEvalOutput
-        // let evaluated =
-        //   new Promise(resolve => state.client.evaluateJSAsync("top.console.log(\"bitty\")", resolve));
-        // let packet = yield evaluated;
+      case "evaluationResult":
+        packet = yield new Promise(resolve => {
+          state.client.evaluateJS(command, resolve);
+        });
         break;
     }
 

--- a/devtools/client/webconsole/new-console-output/test/components/test_console-api-call.html
+++ b/devtools/client/webconsole/new-console-output/test/components/test_console-api-call.html
@@ -20,7 +20,7 @@ window.onload = Task.async(function* () {
   const message = prepareMessage(packet);
   const rendered = renderComponent(ConsoleApiCall, {message});
 
-  const queryPath = "span span.message-flex-body span.message-body.devtools-monospace";
+  const queryPath = "div.message.cm-s-mozilla span span.message-flex-body span.message-body.devtools-monospace";
   const messageBody = rendered.querySelectorAll(queryPath);
   const consoleStringNodes = messageBody[0].querySelectorAll("span.console-string");
   is(consoleStringNodes.length, 2, "ConsoleApiCall outputs expected HTML structure");

--- a/devtools/client/webconsole/new-console-output/test/components/test_date-preview.html
+++ b/devtools/client/webconsole/new-console-output/test/components/test_date-preview.html
@@ -21,7 +21,7 @@ window.onload = Task.async(function* () {
   const message = prepareMessage(packet);
   const rendered = renderComponent(DatePreview, {data: message.data});
 
-  const queryPathBase = "span.message-body-wrapper.message-body.devtools-monospace span span.class-Date";
+  const queryPathBase = "div.message.cm-s-mozilla span.message-body-wrapper.message-body.devtools-monospace span span.class-Date";
 
   const preview = rendered.querySelectorAll(queryPathBase);
   is(preview[0].textContent, testCommand.expectedText, "DatePreview outputs expected text");

--- a/devtools/client/webconsole/new-console-output/test/components/test_date-preview.html
+++ b/devtools/client/webconsole/new-console-output/test/components/test_date-preview.html
@@ -1,0 +1,36 @@
+<!DOCTYPE HTML>
+<html lang="en">
+<head>
+  <meta charset="utf8">
+  <title>Test for DatePreview component</title>
+  <script type="text/javascript" src="chrome://mochikit/content/tests/SimpleTest/SimpleTest.js"></script>
+  <script type="application/javascript;version=1.8" src="head.js"></script>
+  <!-- Any copyright is dedicated to the Public Domain.
+     - http://creativecommons.org/publicdomain/zero/1.0/ -->
+</head>
+<body>
+<p>Test for DatePreview component</p>
+
+<script type="text/javascript;version=1.8">
+window.onload = Task.async(function* () {
+  const { prepareMessage } = require("devtools/client/webconsole/new-console-output/utils/messages");
+  const { DatePreview } = require("devtools/client/webconsole/new-console-output/components/message-types/date-preview");
+
+  const testCommand = testCommands.get("new Date()");
+  const packet = yield getPacket(testCommand.command, testCommand.commandType);
+  const message = prepareMessage(packet);
+  const rendered = renderComponent(DatePreview, {data: message.data});
+
+  const queryPathBase = "span.message-body-wrapper.message-body.devtools-monospace span span.class-Date";
+
+  const preview = rendered.querySelectorAll(queryPathBase);
+  is(preview[0].textContent, testCommand.expectedText, "DatePreview outputs expected text");
+
+  const link = rendered.querySelectorAll(`${queryPathBase} a[draggable=false][href="#"].cm-variable`);
+  is(link.length, 1, "DatePreview outputs the variables view link");
+
+  SimpleTest.finish()
+});
+</script>
+</body>
+</html>

--- a/devtools/client/webconsole/new-console-output/test/components/test_evaluation-result.html
+++ b/devtools/client/webconsole/new-console-output/test/components/test_evaluation-result.html
@@ -46,18 +46,19 @@ window.onload = Task.async(function* () {
   function testGetPreviewComponent() {
     const testValues = [
       {
-        command: testCommands.get("new Date()"),
+        commandObj: testCommands.get("new Date()"),
         expectedComponent: require("devtools/client/webconsole/new-console-output/components/message-types/date-preview").DatePreview
       }
     ];
 
-    testValues.forEach(function(testValue) {
-      const packet = yield getPacket(testValue.command, testValue.commandType);
+    for (let testValue of testValues) {
+      const { commandObj, expectedComponent } = testValue;
+      const packet = yield getPacket(commandObj.command, commandObj.commandType);
       const message = prepareMessage(packet);
       const rendered = shallowRenderComponent(EvaluationResult, {message});
-      is(result.type, testValue.expectedComponent,
-        `EvaluationResult nests ${testValue.expectedComponent} based on command: ${testValue.command}`);
-    });
+      is(rendered.type, expectedComponent,
+        `EvaluationResult nests ${expectedComponent} based on command: ${commandObj.command}`);
+    }
   }
 });
 

--- a/devtools/client/webconsole/new-console-output/test/components/test_evaluation-result.html
+++ b/devtools/client/webconsole/new-console-output/test/components/test_evaluation-result.html
@@ -1,0 +1,66 @@
+<!DOCTYPE HTML>
+<html lang="en">
+<head>
+  <meta charset="utf8">
+  <title>Test for MessageContainer component</title>
+  <script type="text/javascript" src="chrome://mochikit/content/tests/SimpleTest/SimpleTest.js"></script>
+  <script type="application/javascript;version=1.8" src="head.js"></script>
+  <!-- Any copyright is dedicated to the Public Domain.
+     - http://creativecommons.org/publicdomain/zero/1.0/ -->
+</head>
+<body>
+<p>Test for MessageContainer component</p>
+
+<script type="text/javascript;version=1.8">
+window.onload = Task.async(function* () {
+  const { prepareMessage } = require("devtools/client/webconsole/new-console-output/utils/messages");
+  const {
+    EvaluationResult,
+    getPreviewComponent
+  } = require("devtools/client/webconsole/new-console-output/components/message-types/evaluation-result");
+
+  yield testFullRender();
+  yield testGetPreviewComponent();
+
+  SimpleTest.finish()
+
+  /**
+   * Test that passing in a message correctly wires up all the children.
+   *
+   * The different combinations of children are tested in separate per-component
+   * tests. This test just ensures that this component pipes data to its children.
+   */
+  function testFullRender() {
+    const testValue = testCommands.get("new Date()");
+    const packet = yield getPacket(testValue.command, testValue.commandType);
+    const message = prepareMessage(packet);
+    const rendered = renderComponent(EvaluationResult, {message});
+
+    ok(rendered.textContent.contains(testValue.expectedText),
+      "EvaluationResult pipes data to its children as expected");
+}
+
+  /**
+   * Test that getPreviewComponent() returns correct component for each object type.
+   */
+  function testGetPreviewComponent() {
+    const testValues = [
+      {
+        command: testCommands.get("new Date()"),
+        expectedComponent: require("devtools/client/webconsole/new-console-output/components/message-types/date-preview").DatePreview
+      }
+    ];
+
+    testValues.forEach(function(testValue) {
+      const packet = yield getPacket(testValue.command, testValue.commandType);
+      const message = prepareMessage(packet);
+      const rendered = shallowRenderComponent(EvaluationResult, {message});
+      is(result.type, testValue.expectedComponent,
+        `EvaluationResult nests ${testValue.expectedComponent} based on command: ${testValue.command}`);
+    });
+  }
+});
+
+</script>
+</body>
+</html>

--- a/devtools/client/webconsole/new-console-output/test/components/test_evaluation-result.html
+++ b/devtools/client/webconsole/new-console-output/test/components/test_evaluation-result.html
@@ -2,14 +2,14 @@
 <html lang="en">
 <head>
   <meta charset="utf8">
-  <title>Test for MessageContainer component</title>
+  <title>Test for EvaluationResult component</title>
   <script type="text/javascript" src="chrome://mochikit/content/tests/SimpleTest/SimpleTest.js"></script>
   <script type="application/javascript;version=1.8" src="head.js"></script>
   <!-- Any copyright is dedicated to the Public Domain.
      - http://creativecommons.org/publicdomain/zero/1.0/ -->
 </head>
 <body>
-<p>Test for MessageContainer component</p>
+<p>Test for EvaluationResult component</p>
 
 <script type="text/javascript;version=1.8">
 window.onload = Task.async(function* () {

--- a/devtools/client/webconsole/new-console-output/test/components/test_message-container.html
+++ b/devtools/client/webconsole/new-console-output/test/components/test_message-container.html
@@ -46,21 +46,22 @@ window.onload = Task.async(function* () {
   function testGetMessageComponent() {
     const testValues = [
       {
-        command: testCommands.get("console.log()"),
+        commandObj: testCommands.get("console.log()"),
         expectedComponent: ConsoleApiCall
       },
       {
-        command: testCommands.get("new Date()"),
+        commandObj: testCommands.get("new Date()"),
         expectedComponent: EvaluationResult
       }
     ];
 
     for (let testValue of testValues) {
-      const packet = yield getPacket(testValue.command.command, testValue.command.commandType);
+      const { commandObj, expectedComponent } = testValue;
+      const packet = yield getPacket(commandObj.command, commandObj.commandType);
       const message = prepareMessage(packet);
       const rendered = shallowRenderComponent(MessageContainer, {message});
-      is(rendered.type, testValue.expectedComponent,
-        `MessageContainer nests ${testValue.expectedComponent} based on command: ${testValue.command}`);
+      is(rendered.type, expectedComponent,
+        `MessageContainer nests ${expectedComponent} based on command: ${commandObj.command}`);
     }
   }
 });

--- a/devtools/client/webconsole/new-console-output/test/components/test_message-container.html
+++ b/devtools/client/webconsole/new-console-output/test/components/test_message-container.html
@@ -17,6 +17,7 @@ window.onload = Task.async(function* () {
 
   const { MessageContainer } = require("devtools/client/webconsole/new-console-output/components/message-container");
   const { ConsoleApiCall } = require("devtools/client/webconsole/new-console-output/components/message-types/console-api-call");
+  const { EvaluationResult } = require("devtools/client/webconsole/new-console-output/components/message-types/evaluation-result");
 
   yield testFullRender();
   yield testGetMessageComponent();
@@ -47,6 +48,10 @@ window.onload = Task.async(function* () {
       {
         command: testCommands.get("console.log()"),
         expectedComponent: ConsoleApiCall
+      },
+      {
+        command: testCommands.get("new Date()"),
+        expectedComponent: EvaluationResult
       }
     ];
 

--- a/devtools/client/webconsole/new-console-output/utils/messages.js
+++ b/devtools/client/webconsole/new-console-output/utils/messages.js
@@ -7,8 +7,12 @@
 "use strict";
 
 const {
+  CATEGORY_CLASS_FRAGMENTS,
+  CATEGORY_WEBDEV,
+  CATEGORY_OUTPUT,
   LEVELS,
-  SEVERITY_CLASS_FRAGMENTS
+  SEVERITY_CLASS_FRAGMENTS,
+  SEVERITY_LOG,
 } = require("../constants");
 
 function prepareMessage(packet) {
@@ -24,12 +28,22 @@ function prepareMessage(packet) {
   switch (packet.type) {
     case "consoleAPICall":
       allowRepeating = true;
-      category = "console";
+      category = CATEGORY_CLASS_FRAGMENTS[CATEGORY_WEBDEV];
       data = Object.assign({}, packet.message);
       messageType = "ConsoleApiCall";
       repeat = 1;
       repeatId = getRepeatId(packet.message);
       severity = SEVERITY_CLASS_FRAGMENTS[LEVELS[packet.message.level]];
+      break;
+    case "evaluationResult":
+    default:
+      allowRepeating = true;
+      category = CATEGORY_CLASS_FRAGMENTS[CATEGORY_OUTPUT];
+      data = Object.assign({}, packet.result);
+      messageType = "EvaluationResult";
+      repeat = 1;
+      repeatId = getRepeatId(packet.result);
+      severity = SEVERITY_CLASS_FRAGMENTS[SEVERITY_LOG];
       break;
   }
 

--- a/devtools/client/webconsole/webconsole.js
+++ b/devtools/client/webconsole/webconsole.js
@@ -17,10 +17,6 @@ Cu.import("resource://devtools/client/shared/browser-loader.js", BrowserLoaderMo
 const promise = require("promise");
 const Services = require("Services");
 
-// React & Redux
-const React = require("devtools/client/shared/vendor/react");
-const ReactDOM = require("devtools/client/shared/vendor/react-dom");
-
 loader.lazyServiceGetter(this, "clipboardHelper",
                          "@mozilla.org/widget/clipboardhelper;1",
                          "nsIClipboardHelper");


### PR DESCRIPTION
<img width="236" alt="5e5eae26-d19c-11e5-87a3-896f119fed34" src="https://cloud.githubusercontent.com/assets/105464/14302708/cb4e7a12-fb71-11e5-95bf-8954def9864e.png">

```
<div xmlns="http://www.w3.org/1999/xhtml" id="console-msg-8403" class="message cm-s-mozilla" category="output" severity="log" filter="null">
  <span class="timestamp devtools-monospace">15:17:00.491 </span>
  <span class="indent" style="width: 0px;"></span>
  <span class="icon" title="Log"></span>
  <span class="message-body-wrapper message-body devtools-monospace">
    <span>
      <span class="class-Date">
        <a class="cm-variable" draggable="false" href="#">Date</a>
        <span class="cm-string-2">
          2016-02-12T23:17:00.498Z
        </span>
      </span>
    </span>
  </span>
</div>
```

So far, it just implements the stuff inside `message-body-wrapper`.

It still needs to handle objectActors and the link to variables view. Also, some of the tests aren't running (per my comment on the code I landed in the last PR).
