### PR TITLE
Use a higher order component to provide JSTerm functions

### DIFF
--- a/devtools/client/webconsole/new-console-output/components/console-output.js
+++ b/devtools/client/webconsole/new-console-output/components/console-output.js
@@ -16,17 +16,10 @@ const MessageContainer = createFactory(require("devtools/client/webconsole/new-c
 const ConsoleOutput = createClass({
   displayName: "ConsoleOutput",
 
-  propTypes: {
-    jsterm: PropTypes.object.isRequired,
-    // This function is created in mergeProps
-    openVariablesView: PropTypes.func.isRequired
-  },
-
   render() {
-    const { openVariablesView } = this.props;
     let messageNodes = this.props.messages.map(function(message) {
       return (
-        MessageContainer({ message, openVariablesView })
+        MessageContainer({ message })
       );
     });
     return (
@@ -41,13 +34,4 @@ function mapStateToProps(state) {
   };
 }
 
-function mergeProps(stateProps, dispatchProps, ownProps) {
-  const jsterm = ownProps.jsterm;
-  return Object.assign({}, stateProps, dispatchProps, ownProps, {
-    openVariablesView: (objectActor) => {
-      jsterm.openVariablesView({objectActor});
-    }
-  });
-}
-
-module.exports = connect(mapStateToProps, null, mergeProps)(ConsoleOutput);
+module.exports = connect(mapStateToProps)(ConsoleOutput);

--- a/devtools/client/webconsole/new-console-output/components/jsterm-function-provider.js
+++ b/devtools/client/webconsole/new-console-output/components/jsterm-function-provider.js
@@ -1,0 +1,41 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+"use strict";
+
+const {
+  createClass,
+  createElement,
+  DOM: dom,
+  PropTypes
+} = require("devtools/client/shared/vendor/react");
+const { connect } = require("devtools/client/shared/vendor/react-redux");
+
+function provideJSTermFunctions(Component) {
+  const JSTermFunctionProvider = createClass({
+    displayName: "JSTermFunctionProvider",
+
+    render() {
+      return createElement(Component, this.props);
+    }
+  });
+
+  function mapStateToProps(state) {
+    return {
+      jsterm: state.jsterm
+    };
+  }
+
+  function mergeProps(stateProps, dispatchProps, ownProps) {
+    const jsterm = stateProps.jsterm;
+    return Object.assign({}, stateProps, dispatchProps, ownProps, {
+      openVariablesView: (objectActor) => {
+        jsterm.openVariablesView({objectActor});
+      }
+    });
+  }
+
+  return connect(mapStateToProps, null, mergeProps)(JSTermFunctionProvider);
+}
+
+module.exports = provideJSTermFunctions;

--- a/devtools/client/webconsole/new-console-output/components/message-container.js
+++ b/devtools/client/webconsole/new-console-output/components/message-container.js
@@ -17,14 +17,13 @@ const MessageContainer = createClass({
   displayName: "MessageContainer",
 
   propTypes: {
-    message: PropTypes.object.isRequired,
-    openVariablesView: PropTypes.func.isRequired
+    message: PropTypes.object.isRequired
   },
 
   render() {
-    const { message, openVariablesView } = this.props;
+    const { message } = this.props;
     let MessageComponent = getMessageComponent(message.messageType);
-    return createElement(MessageComponent, { message, openVariablesView });
+    return createElement(MessageComponent, { message });
   }
 });
 

--- a/devtools/client/webconsole/new-console-output/components/message-types/date-preview.js
+++ b/devtools/client/webconsole/new-console-output/components/message-types/date-preview.js
@@ -22,15 +22,14 @@ DatePreview.propTypes = {
 };
 
 function DatePreview(props) {
-  const { data, openVariablesView } = props;
+  const { data } = props;
   const { preview } = data;
 
   const dateString = new Date(preview.timestamp).toISOString();
   const textNodes = [
     VariablesViewLink({
       objectActor: data,
-      label: "Date",
-      openVariablesView
+      label: "Date"
     }),
     dom.span({ className: "cm-string-2" }, ` ${dateString}`)
   ];

--- a/devtools/client/webconsole/new-console-output/components/message-types/evaluation-result.js
+++ b/devtools/client/webconsole/new-console-output/components/message-types/evaluation-result.js
@@ -21,9 +21,9 @@ EvaluationResult.propTypes = {
 };
 
 function EvaluationResult(props) {
-  const { message, openVariablesView } = props;
+  const { message } = props;
   let PreviewComponent = getPreviewComponent(message.data);
-  return createElement(PreviewComponent, { data: message.data, openVariablesView });
+  return createElement(PreviewComponent, { data: message.data });
 }
 
 function getPreviewComponent(data) {

--- a/devtools/client/webconsole/new-console-output/components/moz.build
+++ b/devtools/client/webconsole/new-console-output/components/moz.build
@@ -9,6 +9,7 @@ DIRS += [
 
 DevToolsModules(
     'console-output.js',
+    'jsterm-function-provider.js',
     'message-container.js',
     'message-repeat.js',
     'variables-view-link.js'

--- a/devtools/client/webconsole/new-console-output/components/variables-view-link.js
+++ b/devtools/client/webconsole/new-console-output/components/variables-view-link.js
@@ -11,6 +11,7 @@ const {
   DOM: dom,
   PropTypes
 } = require("devtools/client/shared/vendor/react");
+const provideJSTermFunctions = require("devtools/client/webconsole/new-console-output/components/jsterm-function-provider");
 
 VariablesViewLink.displayName = "VariablesViewLink";
 
@@ -31,4 +32,4 @@ function VariablesViewLink(props) {
   }, label);
 }
 
-module.exports.VariablesViewLink = VariablesViewLink;
+module.exports.VariablesViewLink = provideJSTermFunctions(VariablesViewLink);

--- a/devtools/client/webconsole/new-console-output/create-store.js
+++ b/devtools/client/webconsole/new-console-output/create-store.js
@@ -10,9 +10,5 @@ function storeFactory(initialState = {}) {
   return createStore(combineReducers(reducers), initialState);
 }
 
-// Provide the single store instance for app code.
-module.exports.store = storeFactory();
-// Provide the store factory for test code so that each test is working with
-// its own instance.
-module.exports.storeFactory = storeFactory;
+module.exports = storeFactory;
 

--- a/devtools/client/webconsole/new-console-output/moz.build
+++ b/devtools/client/webconsole/new-console-output/moz.build
@@ -12,9 +12,9 @@ DIRS += [
 
 DevToolsModules(
     'constants.js',
+    'create-store.js',
     'main.js',
     'output-wrapper-thingy.js',
-    'store.js',
 )
 
 MOCHITEST_CHROME_MANIFESTS += [

--- a/devtools/client/webconsole/new-console-output/output-wrapper-thingy.js
+++ b/devtools/client/webconsole/new-console-output/output-wrapper-thingy.js
@@ -8,27 +8,25 @@ const React = require("devtools/client/shared/vendor/react");
 const ReactDOM = require("devtools/client/shared/vendor/react-dom");
 const { Provider } = require("devtools/client/shared/vendor/react-redux");
 
-const {
-  MESSAGE_ADD,
-  MESSAGES_CLEAR
-} = require("devtools/client/webconsole/new-console-output/constants");
 const actions = require("devtools/client/webconsole/new-console-output/actions/messages");
-const { store } = require("devtools/client/webconsole/new-console-output/store");
+const createStore = require("devtools/client/webconsole/new-console-output/create-store");
 
 const ConsoleOutput = React.createFactory(require("devtools/client/webconsole/new-console-output/components/console-output"));
 
 function OutputWrapperThingy(parentNode, jsterm) {
-  let childComponent = ConsoleOutput({ jsterm });
-  let provider = React.createElement(Provider, { store: store }, childComponent);
+  this.store = createStore({jsterm});
+  let childComponent = ConsoleOutput();
+  let provider = React.createElement(Provider, { store: this.store },
+    childComponent);
   this.body = ReactDOM.render(provider, parentNode);
 }
 
 OutputWrapperThingy.prototype = {
-  dispatchMessageAdd: (message) => {
-    store.dispatch(actions.messageAdd(message));
+  dispatchMessageAdd: function(message) {
+    this.store.dispatch(actions.messageAdd(message));
   },
-  dispatchMessagesClear: () => {
-    store.dispatch(actions.messagesClear());
+  dispatchMessagesClear: function() {
+    this.store.dispatch(actions.messagesClear());
   }
 };
 

--- a/devtools/client/webconsole/new-console-output/reducers/jsterm.js
+++ b/devtools/client/webconsole/new-console-output/reducers/jsterm.js
@@ -5,10 +5,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 
-const { jsterm } = require("./jsterm");
-const { messages } = require("./messages");
+// @TODO This is here so we can hold on to JSTerm and call functions on it.
+// It will be removed once JSTerm functionality is handled with actions.
+function jsterm(state = [], action) {
+  return state;
+}
 
-exports.reducers = {
-  jsterm,
-  messages
-};
+exports.jsterm = jsterm;

--- a/devtools/client/webconsole/new-console-output/reducers/moz.build
+++ b/devtools/client/webconsole/new-console-output/reducers/moz.build
@@ -5,5 +5,6 @@
 
 DevToolsModules(
     'index.js',
+    'jsterm.js',
     'messages.js',
 )

--- a/devtools/client/webconsole/new-console-output/test/components/test_date-preview.html
+++ b/devtools/client/webconsole/new-console-output/test/components/test_date-preview.html
@@ -20,9 +20,7 @@ window.onload = Task.async(function* () {
   const packet = yield getPacket(testCommand.command, testCommand.commandType);
   const message = prepareMessage(packet);
   const props = {
-    data: message.data,
-    // @TODO test the click handler in an end-to-end test.
-    openVariablesView: () => {}
+    data: message.data
   };
   const rendered = renderComponent(DatePreview, props);
 

--- a/devtools/client/webconsole/new-console-output/test/components/test_evaluation-result.html
+++ b/devtools/client/webconsole/new-console-output/test/components/test_evaluation-result.html
@@ -35,8 +35,7 @@ window.onload = Task.async(function* () {
     const packet = yield getPacket(testValue.command, testValue.commandType);
     const message = prepareMessage(packet);
     const props = {
-      message,
-      openVariablesView: () => {}
+      message
     };
     const rendered = renderComponent(EvaluationResult, props);
 

--- a/devtools/client/webconsole/new-console-output/test/components/test_message-container.html
+++ b/devtools/client/webconsole/new-console-output/test/components/test_message-container.html
@@ -35,8 +35,7 @@ window.onload = Task.async(function* () {
     const packet = yield getPacket(testValue.command, testValue.commandType);
     const message = prepareMessage(packet);
     const props = {
-      message,
-      openVariablesView: () => {}
+      message
     };
     const rendered = renderComponent(MessageContainer, props);
 


### PR DESCRIPTION
I wasn't happy with the way we had to thread the JSTerm function through the component tree. I thought it might be worth using a higher order component to provide the function directly.

There is one problem with this. It means we can't test the date-preview component as directly... we would either need to shallow render, or use a mock Provider to provide the store for the connect call.

Let's talk about this before committing to it.
