### PR TITLE
Use Immutable data structures in messages reducer.

### DIFF
--- a/devtools/client/webconsole/new-console-output/reducers/messages.js
+++ b/devtools/client/webconsole/new-console-output/reducers/messages.js
@@ -5,22 +5,23 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 
+const Immutable = require("devtools/client/shared/vendor/immutable");
 const constants = require("devtools/client/webconsole/new-console-output/constants");
 
-function messages(state = [], action) {
+function messages(state = Immutable.List(), action) {
   switch (action.type) {
     case constants.MESSAGE_ADD:
       let newMessage = action.message;
-      if (newMessage.allowRepeating && state.length > 0) {
-        let lastMessage = state[state.length - 1];
+      if (newMessage.allowRepeating && state.size > 0) {
+        let lastMessage = state.last();
         if (lastMessage.repeatId === newMessage.repeatId) {
           newMessage.repeat = lastMessage.repeat + 1;
-          return state.slice(0, state.length - 1).concat(newMessage);
+          return state.pop().push(newMessage);
         }
       }
-      return state.concat([ newMessage ]);
+      return state.push(newMessage);
     case constants.MESSAGES_CLEAR:
-      return [];
+      return Immutable.List();
   }
 
   return state;

--- a/devtools/client/webconsole/new-console-output/test/store/test_messages.js
+++ b/devtools/client/webconsole/new-console-output/test/store/test_messages.js
@@ -24,7 +24,8 @@ add_task(function*() {
 
   const expectedMessage = prepareMessage(packet);
 
-  deepEqual(getAllMessages(getState()), [expectedMessage],
+  let messages = getAllMessages(getState());
+  deepEqual(messages.toArray(), [expectedMessage],
     "MESSAGE_ADD action adds a message");
 });
 
@@ -41,8 +42,9 @@ add_task(function*() {
   const expectedMessage = prepareMessage(packet);
   expectedMessage.repeat = 3;
 
-  deepEqual(getAllMessages(getState()), [expectedMessage],
-    "Adding same message to the store twice results in repeated message");
+  let messages = getAllMessages(getState());
+  deepEqual(messages.toArray(), [expectedMessage],
+    "Adding same message to the store three times results in repeated message");
 });
 
 /**


### PR DESCRIPTION
Basically, switch `state` from Array to Immutable.List.
Require immutable.js (already in the tree).
Fix tests that are affected by this change.
