### PR TITLE
[WIP] Prototype using reps

### DIFF
--- a/devtools/client/shared/components/reps/grip-array.js
+++ b/devtools/client/shared/components/reps/grip-array.js
@@ -30,28 +30,31 @@ define(function(require, exports, module) {
 
     displayName: "GripArray",
 
-    getLength: function(grip) {
+    getLength: function (grip) {
       return grip.preview ? grip.preview.length : 0;
     },
 
-    getTitle: function(object, context) {
-      return "[" + object.length + "]";
+    getTitle: function (object, titleLinkHandler) {
+      if (titleLinkHandler) {
+        return a({
+          className: "variableViewLink",
+          onClick: titleLinkHandler
+        }, object.class);
+      }
+      return "";
     },
 
-    arrayIterator: function(grip, max) {
+    arrayIterator: function (grip, max) {
       let items = [];
 
       if (!grip.preview || !grip.preview.length) {
+        console.log("no preview");
         return items;
       }
 
       let array = grip.preview.items;
       if (!array) {
-        return items;
-      }
-
-      let provider = this.props.provider;
-      if (!provider) {
+        console.log("no items");
         return items;
       }
 
@@ -59,7 +62,7 @@ define(function(require, exports, module) {
 
       for (let i = 0; i < array.length && i <= max; i++) {
         try {
-          let value = provider.getValue(array[i]);
+          let value = array[i];
 
           delim = (i == array.length - 1 ? "" : ", ");
 
@@ -89,29 +92,28 @@ define(function(require, exports, module) {
         items.pop();
         items.push(Caption({
           key: "more",
-          object: "more..."}
+          object: "more…"}
         ));
       }
 
       return items;
     },
 
-    hasSpecialProperties: function(array) {
+    hasSpecialProperties: function (array) {
       return false;
     },
 
     // Event Handlers
 
-    onToggleProperties: function(event) {
+    onToggleProperties: function (event) {
     },
 
-    onClickBracket: function(event) {
+    onClickBracket: function (event) {
     },
 
-    render: function() {
+    render: function () {
       let mode = this.props.mode || "short";
       let object = this.props.object;
-
       let items;
 
       if (mode == "tiny") {
@@ -125,6 +127,7 @@ define(function(require, exports, module) {
         ObjectBox({
           className: "array",
           onClick: this.onToggleProperties},
+          this.getTitle(object, this.props.titleLinkHandler),
           a({
             className: "objectLink",
             onclick: this.onClickBracket},
@@ -164,7 +167,7 @@ define(function(require, exports, module) {
 
     displayName: "GripArrayItem",
 
-    render: function() {
+    render: function () {
       let { Rep } = createFactories(require("./rep"));
 
       return (
@@ -184,10 +187,10 @@ define(function(require, exports, module) {
   let Reference = React.createFactory(React.createClass({
     displayName: "Reference",
 
-    render: function() {
+    render: function () {
       return (
         span({title: "Circular reference"},
-          "[...]"
+          "[…]"
         )
       );
     }

--- a/devtools/client/shared/components/reps/grip.js
+++ b/devtools/client/shared/components/reps/grip.js
@@ -6,7 +6,7 @@
 "use strict";
 
 // Make this available to both AMD and CJS environments
-define(function(require, exports, module) {
+define(function (require, exports, module) {
   // ReactJS
   const React = require("devtools/client/shared/vendor/react");
 
@@ -16,7 +16,7 @@ define(function(require, exports, module) {
   const { Caption } = createFactories(require("./caption"));
 
   // Shortcuts
-  const { span } = React.DOM;
+  const { a, span } = React.DOM;
 
   /**
    * @template TODO docs
@@ -29,11 +29,17 @@ define(function(require, exports, module) {
 
     displayName: "Grip",
 
-    getTitle: function() {
+    getTitle: function (object, titleLinkHandler) {
+      if (titleLinkHandler) {
+        return a({
+          className: "variableViewLink",
+          onClick: titleLinkHandler
+        }, object.class);
+      }
       return "";
     },
 
-    longPropIterator: function(object) {
+    longPropIterator: function (object) {
       try {
         return this.propIterator(object, 100);
       } catch (err) {
@@ -42,7 +48,7 @@ define(function(require, exports, module) {
       return [];
     },
 
-    shortPropIterator: function(object) {
+    shortPropIterator: function (object) {
       try {
         return this.propIterator(object, 3);
       } catch (err) {
@@ -51,7 +57,7 @@ define(function(require, exports, module) {
       return [];
     },
 
-    propIterator: function(object, max) {
+    propIterator: function (object, max) {
       // Property filter. Show only interesting properties to the user.
       let isInterestingProp = (type, value) => {
         return (
@@ -68,7 +74,7 @@ define(function(require, exports, module) {
 
       if (props.length <= max) {
         // There are not enough props yet (or at least, not enough props to
-        // be able to know whether we should print "more..." or not).
+        // be able to know whether we should print "more…" or not).
         // Let's display also empty members and functions.
         props = props.concat(this.getProps(object, max, (t, value) => {
           return !isInterestingProp(t, value);
@@ -77,12 +83,12 @@ define(function(require, exports, module) {
 
       // getProps() can return max+1 properties (it can't return more)
       // to indicate that there is more props than allowed. Remove the last
-      // one and append 'more...' postfix in such case.
+      // one and append 'more…' postfix in such case.
       if (props.length > max) {
         props.pop();
         props.push(Caption({
           key: "more",
-          object: "more...",
+          object: "more…",
         }));
       } else if (props.length > 0) {
         // Remove the last comma.
@@ -97,7 +103,7 @@ define(function(require, exports, module) {
       return props;
     },
 
-    getProps: function(object, max, filter) {
+    getProps: function (object, max, filter) {
       let props = [];
 
       max = max || 3;
@@ -139,7 +145,7 @@ define(function(require, exports, module) {
       return props;
     },
 
-    render: function() {
+    render: function () {
       let object = this.props.object;
       let props = this.shortPropIterator(object);
 
@@ -154,6 +160,7 @@ define(function(require, exports, module) {
 
       return (
         ObjectBox({className: "object"},
+          this.getTitle(object, this.props.titleLinkHandler),
           span({className: "objectTitle"}, this.getTitle(object)),
           span({className: "objectLeftBrace", role: "presentation"}, "{"),
           props,
@@ -175,7 +182,7 @@ define(function(require, exports, module) {
 
     displayName: "PropRep",
 
-    render: function() {
+    render: function () {
       let { Rep } = createFactories(require("./rep"));
 
       return (

--- a/devtools/client/shared/components/reps/string.js
+++ b/devtools/client/shared/components/reps/string.js
@@ -7,7 +7,7 @@
 "use strict";
 
 // Make this available to both AMD and CJS environments
-define(function(require, exports, module) {
+define(function (require, exports, module) {
   // Dependencies
   const React = require("devtools/client/shared/vendor/react");
   const { createFactories } = require("./rep-utils");
@@ -19,20 +19,22 @@ define(function(require, exports, module) {
   const StringRep = React.createClass({
     displayName: "StringRep",
 
-    render: function() {
+    render: function () {
       let text = this.props.object;
       let member = this.props.member;
-      if (member && member.open) {
+      let preventCropString = this.props.preventCropString;
+      if ((member && member.open) || preventCropString === true) {
         return (
           ObjectBox({className: "string"},
-            "\"" + text + "\""
+            addSurroundingQuotes(text, this.props.hideSurroundingQuotes)
           )
         );
       }
 
       return (
         ObjectBox({className: "string"},
-          "\"" + cropMultipleLines(text) + "\""
+          addSurroundingQuotes(cropMultipleLines(text),
+            this.props.hideSurroundingQuotes)
         )
       );
     },
@@ -89,6 +91,13 @@ define(function(require, exports, module) {
 
   function supportsObject(object, type) {
     return (type == "string");
+  }
+
+  function addSurroundingQuotes(text, hideSurroundingQuotes) {
+    if (hideSurroundingQuotes === true) {
+      return text;
+    }
+    return `"${text}"`;
   }
 
   // Exports from this module

--- a/devtools/client/webconsole/new-console-output/components/console-output.js
+++ b/devtools/client/webconsole/new-console-output/components/console-output.js
@@ -18,9 +18,8 @@ const MessageContainer = createFactory(require("devtools/client/webconsole/new-c
 const ConsoleOutput = createClass({
 
   propTypes: {
-    jsterm: PropTypes.object.isRequired,
     // This function is created in mergeProps
-    openVariablesView: PropTypes.func.isRequired,
+    jsterm: PropTypes.object.isRequired,
     messages: PropTypes.array.isRequired
   },
 
@@ -42,9 +41,11 @@ const ConsoleOutput = createClass({
   },
 
   render() {
-    let messageNodes = this.props.messages.map(function(message) {
+    let {jsterm, messages} = this.props;
+    let messageNodes = messages.map((message) => {
       return (
-        MessageContainer({ message })
+        MessageContainer({ message,
+          openVariablesView: jsterm.openVariablesView.bind(jsterm) })
       );
     });
     return (

--- a/devtools/client/webconsole/new-console-output/components/message-container.js
+++ b/devtools/client/webconsole/new-console-output/components/message-container.js
@@ -16,15 +16,16 @@ const {
 const MessageContainer = createClass({
 
   propTypes: {
+    openVariablesView: PropTypes.func.isRequired,
     message: PropTypes.object.isRequired
   },
 
   displayName: "MessageContainer",
 
   render() {
-    const { message } = this.props;
+    const { message, openVariablesView } = this.props;
     let MessageComponent = getMessageComponent(message.messageType);
-    return MessageComponent({ message });
+    return MessageComponent({ message, openVariablesView });
   }
 });
 

--- a/devtools/client/webconsole/new-console-output/components/message-types/console-api-call.js
+++ b/devtools/client/webconsole/new-console-output/components/message-types/console-api-call.js
@@ -12,20 +12,23 @@ const {
   DOM: dom,
   PropTypes
 } = require("devtools/client/shared/vendor/react");
+const { createFactories } = require("devtools/client/shared/components/reps/rep-utils");
+const { Rep } = createFactories(require("devtools/client/shared/components/reps/rep"));
 const MessageRepeat = createFactory(require("devtools/client/webconsole/new-console-output/components/message-repeat").MessageRepeat);
 const MessageIcon = createFactory(require("devtools/client/webconsole/new-console-output/components/message-icon").MessageIcon);
 
 ConsoleApiCall.displayName = "ConsoleApiCall";
 
 ConsoleApiCall.propTypes = {
-  message: PropTypes.object.isRequired,
+  openVariablesView: PropTypes.func.isRequired,
+  message: PropTypes.object.isRequired
 };
 
 function ConsoleApiCall(props) {
-  const { message } = props;
+  const { message, openVariablesView } = props;
   const messageBody =
     dom.span({className: "message-body devtools-monospace"},
-      formatTextContent(message.data.arguments));
+      buildReps(message.data.arguments, openVariablesView));
   const icon = MessageIcon({severity: message.severity});
   const repeat = MessageRepeat({repeat: message.repeat});
   const children = [
@@ -53,13 +56,17 @@ function ConsoleApiCall(props) {
   );
 }
 
-function formatTextContent(args) {
-  return args.map(function(arg, i, arr) {
-    const str = dom.span({className: "console-string"}, arg);
-    if (i < arr.length - 1) {
-      return [str, " "];
-    }
-    return str;
+function buildReps(args, openVariablesView) {
+  return args.map(function (arg, i, arr) {
+    return Rep({
+      object: arg,
+      hideSurroundingQuotes: true,
+      preventCropString: true,
+      titleLinkHandler: function () {
+        console.log("titleLinkHandler clicked", arg);
+        openVariablesView({objectActor: arg});
+      }
+    });
   });
 }
 


### PR DESCRIPTION
A wip for issue #43 , based on https://github.com/bgrins/gecko-dev/pull/84/commits/ad8134af87168105b98382d4db01c42e540bc3c3 . I'm putting this here because I'm unsure of how far we should go on this one. This patch has some console.log, I'll clean it up when I ask for "real" review.

For now, it seems to work fine : 
- it displays array, object, string, kind of like we want 
- it opens the variable view when clicking on the title

But, it doesn't looks like what it used to be, (Rep styles seem to differ from webconsole's one). Should this be taken care of, and how ? (adding specific Rep's rules on webconsole.css ?)
Also, should we handle all the Reps, or lands a small subset and add support for each type one by one ? 

---

@janodvarko , thanks for your advices on Reps. I implemented what you suggested, can you check if the modifications on the Reps look good to you ?
Also, should we modify the Rep on this issue, or should we make it on a separate commit ?  
