### PR TITLE
Add support for console.trace(). r=bgrins,linclark

### DIFF
--- a/devtools/client/webconsole/new-console-output/components/function-call.js
+++ b/devtools/client/webconsole/new-console-output/components/function-call.js
@@ -1,0 +1,49 @@
+/* -*- indent-tabs-mode: nil; js-indent-level: 2 -*- */
+/* vim: set ft=javascript ts=2 et sw=2 tw=80: */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+// React & Redux
+const {
+  createClass,
+  DOM,
+  PropTypes
+} = require("devtools/client/shared/vendor/react");
+const {l10n} = require("devtools/client/webconsole/new-console-output/utils/messages");
+
+const FunctionCall = createClass({
+
+  propTypes: {
+    functionCall: PropTypes.object.isRequired
+  },
+
+  displayName: "FunctionCall",
+
+  render() {
+    let { functionName, asyncCause} = this.props;
+
+    let isAnonymousFunction = functionName === "";
+    let className = isAnonymousFunction ? "cm-comment" : "cm-variable";
+    let suffix = isAnonymousFunction ? "" : "()";
+    if (isAnonymousFunction) {
+      functionName = l10n.getStr("stacktrace.anonymousFunction");
+    }
+
+    let asyncCauseText = "";
+    if (asyncCause) {
+      asyncCauseText = l10n.getFormatStr("stacktrace.asyncStack", [asyncCause]) + " ";
+    }
+
+    return (
+      DOM.span({className: "function"},
+        DOM.span({className: className}, asyncCauseText + functionName),
+        suffix
+      )
+    );
+  }
+});
+
+module.exports.FunctionCall = FunctionCall;

--- a/devtools/client/webconsole/new-console-output/components/message-types/console-api-call.js
+++ b/devtools/client/webconsole/new-console-output/components/message-types/console-api-call.js
@@ -14,6 +14,7 @@ const {
 } = require("devtools/client/shared/vendor/react");
 const MessageRepeat = createFactory(require("devtools/client/webconsole/new-console-output/components/message-repeat").MessageRepeat);
 const MessageIcon = createFactory(require("devtools/client/webconsole/new-console-output/components/message-icon").MessageIcon);
+const Stacktrace = createFactory(require("devtools/client/webconsole/new-console-output/components/stacktrace").Stacktrace);
 
 ConsoleApiCall.displayName = "ConsoleApiCall";
 
@@ -23,9 +24,26 @@ ConsoleApiCall.propTypes = {
 
 function ConsoleApiCall(props) {
   const { message } = props;
+
+  let content;
+  if (message.data.level === "trace") {
+    content = [
+      dom.span({className: "cm-variable"}, "console"),
+      ".",
+      dom.span({className: "cm-property"}, "trace"),
+      "():"
+    ];
+  } else {
+    content = formatTextContent(message.data.arguments);
+  }
+
+  let container = "";
+  if (message.data.stacktrace) {
+    container = Stacktrace({stacktrace: message.data.stacktrace});
+  }
+
   const messageBody =
-    dom.span({className: "message-body devtools-monospace"},
-      formatTextContent(message.data.arguments));
+    dom.span({className: "message-body devtools-monospace"}, content);
   const icon = MessageIcon({severity: message.severity});
   const repeat = MessageRepeat({repeat: message.repeat});
   const children = [
@@ -40,14 +58,16 @@ function ConsoleApiCall(props) {
     class: "message cm-s-mozilla",
     is: "fdt-message",
     category: message.category,
-    severity: message.severity
+    severity: message.severity,
+    open: (message.data.level === "trace")
   },
     icon,
     dom.span({className: "message-body-wrapper"},
       dom.span({},
         dom.span({className: "message-flex-body"},
           children
-        )
+        ),
+        container
       )
     )
   );

--- a/devtools/client/webconsole/new-console-output/components/moz.build
+++ b/devtools/client/webconsole/new-console-output/components/moz.build
@@ -9,8 +9,10 @@ DIRS += [
 
 DevToolsModules(
     'console-output.js',
+    'function-call.js',
     'message-container.js',
     'message-icon.js',
     'message-repeat.js',
+    'stacktrace.js',
     'variables-view-link.js'
 )

--- a/devtools/client/webconsole/new-console-output/components/stacktrace.js
+++ b/devtools/client/webconsole/new-console-output/components/stacktrace.js
@@ -1,0 +1,39 @@
+/* -*- indent-tabs-mode: nil; js-indent-level: 2 -*- */
+/* vim: set ft=javascript ts=2 et sw=2 tw=80: */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+// React & Redux
+const {
+  createClass,
+  createFactory,
+  DOM,
+  PropTypes
+} = require("devtools/client/shared/vendor/react");
+const FunctionCall = createFactory(require("devtools/client/webconsole/new-console-output/components/function-call").FunctionCall);
+const Stacktrace = createClass({
+
+  propTypes: {
+    stacktrace: PropTypes.array.isRequired
+  },
+
+  displayName: "Stacktrace",
+
+  render() {
+    const { stacktrace } = this.props;
+    return (
+      DOM.ul({
+        className: "stacktrace devtools-monospace"
+      }, buildFunctionCalls(stacktrace))
+    );
+  }
+});
+
+function buildFunctionCalls(stacktrace) {
+  return stacktrace.map((item) => DOM.li({}, FunctionCall(item)));
+}
+
+module.exports.Stacktrace = Stacktrace;

--- a/devtools/client/webconsole/new-console-output/test/components/chrome.ini
+++ b/devtools/client/webconsole/new-console-output/test/components/chrome.ini
@@ -5,9 +5,12 @@ support-files =
 
 [test_console-api-call.html]
 [test_console-api-call_repeat.html]
+[test_console-api-call_trace.html]
 [test_date-preview.html]
 [test_evaluation-result.html]
+[test_function-call.html]
 [test_message-icon.html]
 [test_message-container.html]
 [test_message-repeat.html]
 [test_page-error.html]
+[test_stacktrace.html]

--- a/devtools/client/webconsole/new-console-output/test/components/test_console-api-call_trace.html
+++ b/devtools/client/webconsole/new-console-output/test/components/test_console-api-call_trace.html
@@ -1,0 +1,39 @@
+<!DOCTYPE HTML>
+<html lang="en">
+<head>
+  <meta charset="utf8">
+  <title>Test for ConsoleApiCall component</title>
+  <script type="text/javascript" src="chrome://mochikit/content/tests/SimpleTest/SimpleTest.js"></script>
+  <script type="application/javascript;version=1.8" src="head.js"></script>
+  <!-- Any copyright is dedicated to the Public Domain.
+     - http://creativecommons.org/publicdomain/zero/1.0/ -->
+</head>
+<body>
+<p>Test for ConsoleApiCall component with console.trace</p>
+
+<script type="text/javascript;version=1.8">
+"use strict";
+window.onload = Task.async(function* () {
+  const { prepareMessage } = require("devtools/client/webconsole/new-console-output/utils/messages");
+  const { ConsoleApiCall } = require("devtools/client/webconsole/new-console-output/components/message-types/console-api-call");
+
+  const packet = yield getPacket("console.trace()", "consoleAPICall");
+  const message = prepareMessage(packet);
+  const rendered = renderComponent(ConsoleApiCall, {message});
+  is(rendered.getAttribute("open"), "true",
+    "ConsoleApiCall has the expected value for the open attribute");
+
+  const queryPath = "div.message.cm-s-mozilla span span.message-flex-body " +
+    "span.message-body.devtools-monospace";
+  const messageBody = rendered.querySelectorAll(queryPath);
+  is(messageBody[0].textContent, "console.trace():",
+    "ConsoleApiCall outputs expected text");
+
+  const stacktraceQueryPath = "div.message.cm-s-mozilla ul.stacktrace";
+  is(rendered.querySelectorAll(stacktraceQueryPath).length, 1,
+    "ConsoleApiCall outputs one stacktrace element");
+  SimpleTest.finish();
+});
+</script>
+</body>
+</html>

--- a/devtools/client/webconsole/new-console-output/test/components/test_function-call.html
+++ b/devtools/client/webconsole/new-console-output/test/components/test_function-call.html
@@ -1,0 +1,53 @@
+<!DOCTYPE HTML>
+<html lang="en">
+<head>
+  <meta charset="utf8">
+  <title>Test for FunctionCall component</title>
+  <script type="text/javascript" src="chrome://mochikit/content/tests/SimpleTest/SimpleTest.js"></script>
+  <script type="application/javascript;version=1.8" src="head.js"></script>
+  <!-- Any copyright is dedicated to the Public Domain.
+     - http://creativecommons.org/publicdomain/zero/1.0/ -->
+</head>
+<body>
+<p>Test for FunctionCall component</p>
+
+<script type="text/javascript;version=1.8">
+"use strict";
+window.onload = Task.async(function* () {
+  const { FunctionCall } = require("devtools/client/webconsole/new-console-output/components/function-call");
+
+  info("Test named function call");
+  const namedFunctionCallRendered = renderComponent(FunctionCall, {
+    functionName: "foo"
+  });
+  ok(namedFunctionCallRendered.classList.contains("function"),
+    "FunctionCall component has expected class");
+  is(namedFunctionCallRendered.textContent, "foo()",
+    "Named FunctionCall has the expected text content");
+  ok(namedFunctionCallRendered.firstChild.classList.contains("cm-variable"),
+    "Named FunctionCall children has the expected className");
+
+  info("Test anonymous function call");
+  const anonymousFunctionCallRendered = renderComponent(FunctionCall, {
+    functionName: ""
+  });
+  ok(anonymousFunctionCallRendered.classList.contains("function"),
+    "FunctionCall component has expected class");
+  is(anonymousFunctionCallRendered.textContent, "<anonymous>",
+    "Anonymous FunctionCall has the expected text content");
+  ok(anonymousFunctionCallRendered.firstChild.classList.contains("cm-comment"),
+    "Anonymous FunctionCall children has the expected className");
+
+  info("Test async function call");
+  const asyncFunctionCallRendered = renderComponent(FunctionCall, {
+    functionName: "bar",
+    asyncCause: "setTimeout handler"
+  });
+  is(asyncFunctionCallRendered.textContent, "(Async: setTimeout handler) bar()",
+    "Async FunctionCall has the expected text content");
+
+  SimpleTest.finish();
+});
+</script>
+</body>
+</html>

--- a/devtools/client/webconsole/new-console-output/test/components/test_stacktrace.html
+++ b/devtools/client/webconsole/new-console-output/test/components/test_stacktrace.html
@@ -1,0 +1,41 @@
+<!DOCTYPE HTML>
+<html lang="en">
+<head>
+  <meta charset="utf8">
+  <title>Test for Stacktrace component</title>
+  <script type="text/javascript" src="chrome://mochikit/content/tests/SimpleTest/SimpleTest.js"></script>
+  <script type="application/javascript;version=1.8" src="head.js"></script>
+  <!-- Any copyright is dedicated to the Public Domain.
+     - http://creativecommons.org/publicdomain/zero/1.0/ -->
+</head>
+<body>
+<p>Test for Stacktrace component</p>
+
+<script type="text/javascript;version=1.8">
+"use strict";
+window.onload = Task.async(function* () {
+  const { Stacktrace } = require("devtools/client/webconsole/new-console-output/components/stacktrace");
+
+  let mock = [{
+    functionName: "foo",
+    asyncCause: null
+  }, {
+    functionName: "bar",
+    asyncCause: null
+  }, {
+    functionName: "",
+    asyncCause: null
+  }];
+  const stacktraceRendered = renderComponent(Stacktrace, { stacktrace: mock });
+  ok(stacktraceRendered.classList.contains("stacktrace"),
+    "Stacktrace has expected class");
+
+  const functionCalls = stacktraceRendered.querySelectorAll("li");
+  is(functionCalls.length, 3,
+    "Stacktrace has the expected number of li items");
+
+  SimpleTest.finish();
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
For issue #66.
Add a Stacktrace and a FunctionCall component to display the stack trace.
We will be able to re-use it for the error messages stack trace too.
