### PR TITLE
Display cached messages in new console frontend. r=linclark

### DIFF
--- a/devtools/client/webconsole/new-console-output/utils/messages.js
+++ b/devtools/client/webconsole/new-console-output/utils/messages.js
@@ -21,6 +21,22 @@ const WebConsoleUtils = require("devtools/shared/webconsole/utils").Utils;
 const STRINGS_URI = "chrome://devtools/locale/webconsole.properties";
 const l10n = new WebConsoleUtils.L10n(STRINGS_URI);
 
+function convertCachedPacket(packet) {
+  // The devtools server provides cached message packets in a different shape
+  // from those of consoleApiCalls, so we prepare them for preparation here.
+  let convertPacket = {};
+  if (packet._type === "ConsoleAPI") {
+    convertPacket.message = packet;
+    convertPacket.type = "consoleAPICall";
+  } else if (packet._type === "PageError") {
+    convertPacket.pageError = packet;
+    convertPacket.type = "pageError";
+  } else {
+    throw new Error("Unexpected packet type");
+  }
+  return convertPacket;
+}
+
 function prepareMessage(packet) {
   // @TODO turn this into an Immutable Record.
   let allowRepeating;
@@ -30,6 +46,10 @@ function prepareMessage(packet) {
   let repeat;
   let repeatId;
   let severity;
+
+  if (packet._type) {
+    packet = convertCachedPacket(packet);
+  }
 
   switch (packet.type) {
     case "consoleAPICall":

--- a/devtools/client/webconsole/webconsole.js
+++ b/devtools/client/webconsole/webconsole.js
@@ -3335,19 +3335,7 @@ WebConsoleConnectionProxy.prototype = {
 
     if (this.webConsoleFrame.NEW_CONSOLE_OUTPUT_ENABLED) {
       for (let packet of messages) {
-        // The packet returned from getCachedMessages has different shape from
-        // packets in onConsoleApiCall.
-        let convertPacket = {};
-        if (packet._type === "ConsoleAPI") {
-          convertPacket.message = packet;
-          convertPacket.type = "consoleAPICall";
-        } else if (packet._type === "PageError") {
-          convertPacket.pageError = packet;
-          convertPacket.type = "pageError";
-        } else {
-          throw new Error("Unexpected packet type");
-        }
-        this.webConsoleFrame.newConsoleOutput.dispatchMessageAdd(convertPacket);
+        this.webConsoleFrame.newConsoleOutput.dispatchMessageAdd(packet);
       }
     } else {
       this.webConsoleFrame.displayCachedMessages(messages);


### PR DESCRIPTION
Looked with @bgrins, couldn't decide whether to wait on tests like https://dxr.mozilla.org/mozilla-central/source/devtools/client/webconsole/test/browser_cached_messages.js to work with the new frontend or to add a new one.
r? @linclark
