### PR TITLE
Introduce message limit in the new console frontend. r=linclark

### DIFF
--- a/devtools/client/preferences/devtools.js
+++ b/devtools/client/preferences/devtools.js
@@ -296,6 +296,9 @@ pref("devtools.webconsole.autoMultiline", true);
 // Enable the experimental webconsole frontend (work in progress)
 pref("devtools.webconsole.new-frontend-enabled", false);
 
+// The number of lines that are displayed in the web console.
+pref("devtools.hud.loglimit", 1000);
+
 // The number of lines that are displayed in the web console for the Net,
 // CSS, JS and Web Developer categories. These defaults should be kept in sync
 // with DEFAULT_LOG_LIMIT in the webconsole frontend.

--- a/devtools/client/webconsole/new-console-output/reducers/moz.build
+++ b/devtools/client/webconsole/new-console-output/reducers/moz.build
@@ -6,4 +6,5 @@
 DevToolsModules(
     'index.js',
     'messages.js',
+    'prefs.js',
 )

--- a/devtools/client/webconsole/new-console-output/reducers/prefs.js
+++ b/devtools/client/webconsole/new-console-output/reducers/prefs.js
@@ -5,10 +5,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 
-const { messages } = require("./messages");
-const { prefs } = require("./prefs");
+function prefs(state = {}, action) {
+  return state;
+}
 
-exports.reducers = {
-  messages,
-  prefs,
-};
+exports.prefs = prefs;

--- a/devtools/client/webconsole/new-console-output/selectors/messages.js
+++ b/devtools/client/webconsole/new-console-output/selectors/messages.js
@@ -5,8 +5,18 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 
+const { getLogLimit } = require("devtools/client/webconsole/new-console-output/selectors/prefs");
+
 function getAllMessages(state) {
-  return state.messages;
+  let messages = state.messages;
+  let messageCount = messages.count();
+  let logLimit = getLogLimit(state);
+
+  if (messageCount > logLimit) {
+    return messages.splice(0, messageCount - logLimit);
+  }
+
+  return messages;
 }
 
 exports.getAllMessages = getAllMessages;

--- a/devtools/client/webconsole/new-console-output/selectors/moz.build
+++ b/devtools/client/webconsole/new-console-output/selectors/moz.build
@@ -5,4 +5,5 @@
 
 DevToolsModules(
     'messages.js',
+    'prefs.js',
 )

--- a/devtools/client/webconsole/new-console-output/selectors/prefs.js
+++ b/devtools/client/webconsole/new-console-output/selectors/prefs.js
@@ -5,10 +5,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 
-const { messages } = require("./messages");
-const { prefs } = require("./prefs");
+function getLogLimit(state) {
+  return state.prefs.logLimit;
+}
 
-exports.reducers = {
-  messages,
-  prefs,
-};
+exports.getLogLimit = getLogLimit;

--- a/devtools/client/webconsole/new-console-output/store.js
+++ b/devtools/client/webconsole/new-console-output/store.js
@@ -4,9 +4,18 @@
 "use strict";
 
 const { combineReducers, createStore } = require("devtools/client/shared/vendor/redux");
+const Immutable = require("devtools/client/shared/vendor/immutable");
 const { reducers } = require("./reducers/index");
+const Services = require("Services");
 
-function storeFactory(initialState = {}) {
+function storeFactory() {
+  const initialState = {
+    messages: Immutable.List(),
+    prefs: {
+      logLimit: Math.max(Services.prefs.getIntPref("devtools.hud.loglimit"), 1)
+    }
+  };
+
   return createStore(combineReducers(reducers), initialState);
 }
 

--- a/devtools/client/webconsole/new-console-output/test/store/head.js
+++ b/devtools/client/webconsole/new-console-output/test/store/head.js
@@ -7,6 +7,7 @@
 
 var { utils: Cu } = Components;
 var { require } = Cu.import("resource://devtools/shared/Loader.jsm", {});
+const Services = require("Services");
 
 var DevToolsUtils = require("devtools/shared/DevToolsUtils");
 DevToolsUtils.testing = true;


### PR DESCRIPTION
This is working well, but I'm unsure about the overall architecture.
Should the prune reducer be in its own file ?
Is the way I declare the reducer in createStore correct ?
If I'm correct, combineReducers lead to having only the property with the same name (messages in our case) as state argument of the reducer, but in this case we need to have access to the root state object in order to get the prefs.
