### PR TITLE
Match current markup in PageError

### DIFF
--- a/devtools/client/webconsole/new-console-output/components/message-types/page-error.js
+++ b/devtools/client/webconsole/new-console-output/components/message-types/page-error.js
@@ -23,33 +23,26 @@ PageError.propTypes = {
 
 function PageError(props) {
   const { message } = props;
-  const messageBody =
-    dom.span({className: "message-body devtools-monospace"},
-      message.data.errorMessage);
   const repeat = MessageRepeat({repeat: message.repeat});
   const icon = MessageIcon({severity: message.severity});
-  const children = [
-    messageBody,
-    repeat
-  ];
 
   // @TODO Use of "is" is a temporary hack to get the category and severity
   // attributes to be applied. There are targeted in webconsole's CSS rules,
   // so if we remove this hack, we have to modify the CSS rules accordingly.
   return dom.div({
-    class: "message cm-s-mozilla",
+    class: "message",
     is: "fdt-message",
     category: message.category,
     severity: message.severity
   },
     icon,
-    dom.span({className: "message-body-wrapper"},
+    dom.span(
+      {className: "message-body-wrapper message-body devtools-monospace"},
       dom.span({},
-        dom.span({className: "message-flex-body"},
-          children
-        )
+        message.data.errorMessage
       )
-    )
+    ),
+    repeat
   );
 }
 

--- a/devtools/client/webconsole/new-console-output/test/components/test_page-error.html
+++ b/devtools/client/webconsole/new-console-output/test/components/test_page-error.html
@@ -20,7 +20,7 @@ window.onload = Task.async(function* () {
   const message = prepareMessage(packet);
   const rendered = renderComponent(PageError, {message});
 
-  const queryPath = "div.message.cm-s-mozilla span span.message-flex-body span.message-body.devtools-monospace";
+  const queryPath = "div.message span.message-body-wrapper.message-body.devtools-monospace";
   const messageBody = rendered.querySelectorAll(queryPath);
   is(messageBody.length, 1, "PageError outputs expected HTML structure");
   is(messageBody[0].textContent, testCommands.get("pageError").expectedText, "PageError outputs expected text");


### PR DESCRIPTION
I noticed this when I was working on the reps PR. The markup here was taken from one of the other message types, but unfortunately since they aren't consistent, that's not actually how PageErrors are displayed.

This ties in to #107. If someone wants to cherry pick this commit and use it as a starting point, I'm fine with that.
