### PR TITLE
Bug 1285348 - New console frontend: disable in browser toolbox. r=bgrins

### DIFF
--- a/devtools/client/webconsole/webconsole.js
+++ b/devtools/client/webconsole/webconsole.js
@@ -501,8 +501,9 @@ WebConsoleFrame.prototype = {
   _initUI: function () {
     this.document = this.window.document;
     this.rootElement = this.document.documentElement;
-    this.NEW_CONSOLE_OUTPUT_ENABLED = !this.owner._browserConsole &&
-      Services.prefs.getBoolPref(PREF_NEW_FRONTEND_ENABLED);
+    this.NEW_CONSOLE_OUTPUT_ENABLED = !this.owner._browserConsole
+      && !this.owner.target.chrome
+      && Services.prefs.getBoolPref(PREF_NEW_FRONTEND_ENABLED);
 
     this._initDefaultFilterPrefs();
 


### PR DESCRIPTION
Fix #51 
## Testing instructions

Load browser toolbox and console.log()

**Before:** your input would not be shown in the console (since it hasn't be implemented yet)
**After:** your input is shown
