### PR TITLE
Use variables view link for object inspection

### DIFF
--- a/devtools/client/webconsole/new-console-output/components/grip-message-body.js
+++ b/devtools/client/webconsole/new-console-output/components/grip-message-body.js
@@ -8,10 +8,12 @@
 
 // React
 const {
+  createFactory,
   PropTypes
 } = require("devtools/client/shared/vendor/react");
 const { createFactories } = require("devtools/client/shared/components/reps/rep-utils");
 const { Rep } = createFactories(require("devtools/client/shared/components/reps/rep"));
+const VariablesViewLink = createFactory(require("devtools/client/webconsole/new-console-output/components/variables-view-link").VariablesViewLink);
 const { Grip } = require("devtools/client/shared/components/reps/grip");
 
 GripMessageBody.displayName = "GripMessageBody";
@@ -23,6 +25,7 @@ GripMessageBody.propTypes = {
 function GripMessageBody(props) {
   return Rep({
     object: props.grip,
+    objectLink: VariablesViewLink,
     defaultRep: Grip
   });
 }


### PR DESCRIPTION
Fix #111 
## Testing instructions

`console.log({foo: {bar: "baz"}})`

**Before**: You couldn't inspect
**After**: You can click on either Object link
