### PR TITLE
Handle `console.count`calls without label. r=linclark

### DIFF
--- a/devtools/client/webconsole/new-console-output/test/components/test_console-api-call.html
+++ b/devtools/client/webconsole/new-console-output/test/components/test_console-api-call.html
@@ -44,8 +44,16 @@ function testConsoleCount() {
 
     const expected = `bar: ${i + 1}`;
     is(messageBody.textContent, expected,
-      "console.count has the expected text content: ${expected}");
+      `console.count has the expected text content: "${expected}"`);
   }
+
+  const packet = yield getPacket("console.count()", "consoleAPICall")
+  const message = prepareMessage(packet);
+  const rendered = renderComponent(ConsoleApiCall, {message: message});
+  const messageBody = getMessageBody(rendered);
+  const expected = "<no label>: 1";
+  is(messageBody.textContent, expected,
+    `console.count without label has the expected text content: "${expected}"`);
 }
 
 function getMessageBody(renderedComponent) {

--- a/devtools/client/webconsole/new-console-output/utils/messages.js
+++ b/devtools/client/webconsole/new-console-output/utils/messages.js
@@ -64,7 +64,9 @@ function transformPacket(packet) {
           // Chrome RDP doesn't have a special type for count.
           type = MESSAGE_TYPE.LOG;
           level = MESSAGE_LEVEL.DEBUG;
-          messageText = `${message.counter.label}: ${message.counter.count}`;
+          let {counter} = message;
+          let label = counter.label ? counter.label : l10n.getStr("noCounterLabel");
+          messageText = `${label}: ${counter.count}`;
           parameters = null;
           break;
       }


### PR DESCRIPTION
Add a test to ensure this.

This is for https://github.com/devtools-html/gecko-dev/issues/144.

Because of https://github.com/devtools-html/gecko-dev/issues/148 , this isn't visible if you try it out, but the test passes and I saw it working by quickly disabling severity filtering.
