### PR TITLE
Fix CSS rules and classes for the FilterBar

### DIFF
--- a/devtools/client/themes/toolbars.css
+++ b/devtools/client/themes/toolbars.css
@@ -248,8 +248,7 @@
 
 .devtools-button[checked]:empty::before,
 .devtools-button[open]:empty::before,
-.devtools-button.active::before,
-.theme-light .devtools-button.active::before,
+.devtools-button.checked::before,
 .devtools-toolbarbutton:not([label])[checked=true] > image,
 .devtools-toolbarbutton:not([label])[open=true] > image {
   filter: var(--checked-icon-filter);
@@ -388,6 +387,15 @@
 .devtools-searchinput .textbox-input::-moz-placeholder,
 .devtools-filterinput .textbox-input::-moz-placeholder {
   font-style: normal;
+}
+
+.devtools-plaininput {
+  border-color: transparent;
+  background-color: transparent;
+}
+
+.theme-dark .devtools-plaininput {
+  color: var(--theme-highlight-gray);
 }
 
 /* Searchbox is a div container element for a search input element */
@@ -679,7 +687,7 @@
   background-color: var(--theme-selection-background-semitransparent);
 }
 
-.menu-filter-button:not(:active).active {
+.menu-filter-button:not(:active).checked {
   background-color: var(--theme-selection-background);
   color: var(--theme-selection-color);
 }

--- a/devtools/client/themes/webconsole.css
+++ b/devtools/client/themes/webconsole.css
@@ -687,15 +687,6 @@ a.learn-more-link.webconsole-learn-more-link {
   display: flex;
 }
 
-.webconsole-filterbar-primary .devtools-plain-input {
+.webconsole-filterbar-primary .devtools-plaininput {
   flex: 1 1 100%;
-}
-
-.devtools-plain-input {
-  border-color: transparent;
-  background-color: transparent;
-}
-
-.theme-dark .devtools-plain-input {
-  color: var(--theme-highlight-gray);
 }

--- a/devtools/client/themes/webconsole.css
+++ b/devtools/client/themes/webconsole.css
@@ -689,5 +689,13 @@ a.learn-more-link.webconsole-learn-more-link {
 
 .webconsole-filterbar-primary .devtools-plain-input {
   flex: 1 1 100%;
+}
+
+.devtools-plain-input {
   border-color: transparent;
+  background-color: transparent;
+}
+
+.theme-dark .devtools-plain-input {
+  color: var(--theme-highlight-gray);
 }

--- a/devtools/client/webconsole/new-console-output/components/filter-bar.js
+++ b/devtools/client/webconsole/new-console-output/components/filter-bar.js
@@ -58,12 +58,12 @@ const FilterBar = createClass({
       }),
       dom.button({
         className: "devtools-button devtools-filter-icon" + (
-          configFilterBarVisible ? " active" : ""),
+          configFilterBarVisible ? " checked" : ""),
         title: "Toggle filter bar",
         onClick: this.onToggleFilterConfigBarButtonClick
       }),
       dom.input({
-        className: "devtools-plain-input",
+        className: "devtools-plaininput",
         type: "search",
         value: filter.text,
         placeholder: "Filter output",

--- a/devtools/client/webconsole/new-console-output/components/filter-toggle-button.js
+++ b/devtools/client/webconsole/new-console-output/components/filter-toggle-button.js
@@ -30,7 +30,7 @@ const FilterToggleButton = createClass({
 
     let classList = ["menu-filter-button"];
     if (active) {
-      classList.push("active");
+      classList.push("checked");
     }
 
     return dom.button({


### PR DESCRIPTION
Fix #167 

@helenvholmes , does it looks good to you ? 

![screenshot at juil 26 18-48-11](https://cloud.githubusercontent.com/assets/578107/17147667/0e029830-5364-11e6-9122-16aa754b665c.png)
![screenshot at juil 26 18-44-10](https://cloud.githubusercontent.com/assets/578107/17147666/0e00e3fa-5364-11e6-8afa-4a5d29798dc4.png)

@nt1m I know there's a comment on a review to switch `devtools-plain-input` to `devtools-plaininput` in MozReview, maybe we could have a follow up to do the renaming ( and maybe move the rules to toolbars.css ? it may be useful for others components)
