### PR TITLE
Adjust severity filtering rules

### DIFF
--- a/devtools/client/webconsole/new-console-output/components/filter-bar.js
+++ b/devtools/client/webconsole/new-console-output/components/filter-bar.js
@@ -97,6 +97,12 @@ const FilterBar = createClass({
             label: "Info",
             filterKey: MESSAGE_LEVEL.INFO,
             dispatch
+          }),
+          FilterButton({
+            active: filter.debug,
+            label: "Debug",
+            filterKey: MESSAGE_LEVEL.DEBUG,
+            dispatch
           })
         )
       );

--- a/devtools/client/webconsole/new-console-output/reducers/filters.js
+++ b/devtools/client/webconsole/new-console-output/reducers/filters.js
@@ -9,11 +9,12 @@ const Immutable = require("devtools/client/shared/vendor/immutable");
 const constants = require("devtools/client/webconsole/new-console-output/constants");
 
 const FilterState = Immutable.Record({
+  debug: true,
   error: true,
-  warn: true,
   info: true,
   log: true,
-  text: ""
+  text: "",
+  warn: true
 });
 
 function filters(state = new FilterState(), action) {

--- a/devtools/client/webconsole/new-console-output/selectors/messages.js
+++ b/devtools/client/webconsole/new-console-output/selectors/messages.js
@@ -7,6 +7,9 @@
 
 const { getAllFilters } = require("devtools/client/webconsole/new-console-output/selectors/filters");
 const { getLogLimit } = require("devtools/client/webconsole/new-console-output/selectors/prefs");
+const {
+  MESSAGE_TYPE
+} = require("devtools/client/webconsole/new-console-output/constants");
 
 function getAllMessages(state) {
   let messages = state.messages;
@@ -23,7 +26,10 @@ function getAllMessages(state) {
 }
 
 function filterSeverity(messages, filters) {
-  return messages.filter((message) => filters[message.level] === true);
+  return messages.filter((message) => {
+    return filters[message.level] === true
+      || [MESSAGE_TYPE.COMMAND, MESSAGE_TYPE.RESULT].includes(message.type);
+  });
 }
 
 function search(messages, text = "") {

--- a/devtools/client/webconsole/new-console-output/test/components/filter-bar.test.js
+++ b/devtools/client/webconsole/new-console-output/test/components/filter-bar.test.js
@@ -65,13 +65,15 @@ describe("FilterBar component:", () => {
     };
     const logButton = FilterButton(Object.assign({}, buttonProps,
       { label: "Logs", filterKey: MESSAGE_LEVEL.LOG }));
+    const debugButton = FilterButton(Object.assign({}, buttonProps,
+      { label: "Debug", filterKey: MESSAGE_LEVEL.DEBUG }));
     const infoButton = FilterButton(Object.assign({}, buttonProps,
       { label: "Info", filterKey: MESSAGE_LEVEL.INFO }));
     const warnButton = FilterButton(Object.assign({}, buttonProps,
       { label: "Warnings", filterKey: MESSAGE_LEVEL.WARN }));
     const errorButton = FilterButton(Object.assign({}, buttonProps,
       { label: "Errors", filterKey: MESSAGE_LEVEL.ERROR }));
-    expect(wrapper.contains([errorButton, warnButton, logButton, infoButton])).toBe(true);
+    expect(wrapper.contains([errorButton, warnButton, logButton, infoButton, debugButton])).toBe(true);
   });
 
   it("fires MESSAGES_CLEAR action when clear button is clicked", () => {

--- a/devtools/client/webconsole/new-console-output/test/store/filters.test.js
+++ b/devtools/client/webconsole/new-console-output/test/store/filters.test.js
@@ -14,14 +14,18 @@ const { setupStore } = require("devtools/client/webconsole/new-console-output/te
 const { MESSAGE_LEVEL } = require("devtools/client/webconsole/new-console-output/constants");
 
 describe("Filtering", () => {
-  const numMessages = 5;
+  const numMessages = 6;
   const store = setupStore([
+    // Console API
     "console.log('foobar', 'test')",
     "console.warn('danger, will robinson!')",
     "console.log(undefined)",
+    // Evaluation Result
+    "new Date(0)",
+    // PageError
     "ReferenceError"
   ]);
-  // Add a console command as well
+  // Console Command
   store.dispatch(messageAdd(new ConsoleCommand({ messageText: `console.warn("x")` })));
 
   beforeEach(() => {
@@ -33,8 +37,7 @@ describe("Filtering", () => {
       store.dispatch(actions.filterToggle(MESSAGE_LEVEL.LOG));
 
       let messages = getAllMessages(store.getState());
-      // @TODO It currently filters console command. This should be -2, not -3.
-      expect(messages.size).toEqual(numMessages - 3);
+      expect(messages.size).toEqual(numMessages - 2);
     });
 
     // @TODO add info stub
@@ -61,8 +64,8 @@ describe("Filtering", () => {
 
       let messages = getAllMessages(store.getState());
       // @TODO figure out what this should filter
-      // This does not filter out PageErrors or console commands
-      expect(messages.size).toEqual(3);
+      // This does not filter out PageErrors, Evaluation Results or console commands
+      expect(messages.size).toEqual(4);
     });
   });
 

--- a/devtools/client/webconsole/new-console-output/test/store/filters.test.js
+++ b/devtools/client/webconsole/new-console-output/test/store/filters.test.js
@@ -14,12 +14,13 @@ const { setupStore } = require("devtools/client/webconsole/new-console-output/te
 const { MESSAGE_LEVEL } = require("devtools/client/webconsole/new-console-output/constants");
 
 describe("Filtering", () => {
-  const numMessages = 6;
+  const numMessages = 7;
   const store = setupStore([
     // Console API
     "console.log('foobar', 'test')",
     "console.warn('danger, will robinson!')",
     "console.log(undefined)",
+    "console.count('bar')",
     // Evaluation Result
     "new Date(0)",
     // PageError
@@ -38,6 +39,13 @@ describe("Filtering", () => {
 
       let messages = getAllMessages(store.getState());
       expect(messages.size).toEqual(numMessages - 2);
+    });
+
+    it("filters debug messages", () => {
+      store.dispatch(actions.filterToggle(MESSAGE_LEVEL.DEBUG));
+
+      let messages = getAllMessages(store.getState());
+      expect(messages.size).toEqual(numMessages - 1);
     });
 
     // @TODO add info stub
@@ -65,7 +73,7 @@ describe("Filtering", () => {
       let messages = getAllMessages(store.getState());
       // @TODO figure out what this should filter
       // This does not filter out PageErrors, Evaluation Results or console commands
-      expect(messages.size).toEqual(4);
+      expect(messages.size).toEqual(5);
     });
   });
 
@@ -84,6 +92,7 @@ describe("Clear filters", () => {
     store.dispatch(actions.filterTextSet("foobar"));
     let filters = getAllFilters(store.getState());
     expect(filters.toJS()).toEqual({
+      "debug": true,
       "error": false,
       "info": true,
       "log": true,
@@ -95,6 +104,7 @@ describe("Clear filters", () => {
 
     filters = getAllFilters(store.getState());
     expect(filters.toJS()).toEqual({
+      "debug": true,
       "error": true,
       "info": true,
       "log": true,


### PR DESCRIPTION
Fixes #126 
## Testing instructions
1. Add the following messages
   
   ```
   console.log("asdf")
   console.count("bar")
   ```
2. Toggle the Log filter on and off. You should only see the log message go away (before, the console command and evaluation result would as well)
3. Toggle the Debug filter. You should see the count message go away.
