### PR TITLE
Add support for console.trace()

### DIFF
--- a/devtools/client/themes/webconsole.css
+++ b/devtools/client/themes/webconsole.css
@@ -552,7 +552,8 @@ a {
   background-color: rgba(0, 0, 0, 0.5);
 }
 
-.message[open] .stacktrace {
+.message[open] .stacktrace,
+.message.open .stacktrace {
   display: block;
 }
 

--- a/devtools/client/webconsole/new-console-output/components/console-output.js
+++ b/devtools/client/webconsole/new-console-output/components/console-output.js
@@ -21,7 +21,8 @@ const ConsoleOutput = createClass({
     jsterm: PropTypes.object.isRequired,
     // This function is created in mergeProps
     openVariablesView: PropTypes.func.isRequired,
-    messages: PropTypes.array.isRequired
+    messages: PropTypes.array.isRequired,
+    onViewSourceInDebugger: PropTypes.func.isRequired,
   },
 
   displayName: "ConsoleOutput",
@@ -41,9 +42,10 @@ const ConsoleOutput = createClass({
   },
 
   render() {
-    let messageNodes = this.props.messages.map(function (message) {
+    let {messages, onViewSourceInDebugger} = this.props;
+    let messageNodes = messages.map(function (message) {
       return (
-        MessageContainer({ message, key: message.id })
+        MessageContainer({ message, key: message.id, onViewSourceInDebugger })
       );
     });
     return (

--- a/devtools/client/webconsole/new-console-output/components/message-container.js
+++ b/devtools/client/webconsole/new-console-output/components/message-container.js
@@ -30,7 +30,8 @@ const MessageContainer = createClass({
   displayName: "MessageContainer",
 
   propTypes: {
-    message: PropTypes.object.isRequired
+    message: PropTypes.object.isRequired,
+    onViewSourceInDebugger: PropTypes.func.isRequired,
   },
 
   shouldComponentUpdate(nextProps, nextState) {
@@ -38,9 +39,9 @@ const MessageContainer = createClass({
   },
 
   render() {
-    const { message } = this.props;
+    const { message, onViewSourceInDebugger } = this.props;
     let MessageComponent = createFactory(getMessageComponent(message));
-    return MessageComponent({ message });
+    return MessageComponent({ message, onViewSourceInDebugger });
   }
 });
 

--- a/devtools/client/webconsole/new-console-output/main.js
+++ b/devtools/client/webconsole/new-console-output/main.js
@@ -18,7 +18,7 @@ const NewConsoleOutputWrapper = BrowserLoader({
   baseURI: "resource://devtools/client/webconsole/new-console-output/",
   window: this}).require("./new-console-output-wrapper");
 
-this.NewConsoleOutput = function (parentNode, jsterm) {
+this.NewConsoleOutput = function (parentNode, jsterm, toolbox) {
   console.log("Creating NewConsoleOutput", parentNode, NewConsoleOutputWrapper);
-  return new NewConsoleOutputWrapper(parentNode, jsterm);
+  return new NewConsoleOutputWrapper(parentNode, jsterm, toolbox);
 };

--- a/devtools/client/webconsole/new-console-output/new-console-output-wrapper.js
+++ b/devtools/client/webconsole/new-console-output/new-console-output-wrapper.js
@@ -16,8 +16,15 @@ const FilterBar = React.createFactory(require("devtools/client/webconsole/new-co
 
 const store = configureStore();
 
-function NewConsoleOutputWrapper(parentNode, jsterm) {
-  let childComponent = ConsoleOutput({ jsterm });
+function NewConsoleOutputWrapper(parentNode, jsterm, toolbox) {
+  let childComponent = ConsoleOutput({
+    jsterm,
+    onViewSourceInDebugger: frame => toolbox.viewSourceInDebugger.call(
+      toolbox,
+      frame.url,
+      frame.line
+    )
+  });
   let filterBar = FilterBar({});
   let provider = React.createElement(
     Provider,

--- a/devtools/client/webconsole/new-console-output/test/fixtures/stubs.js
+++ b/devtools/client/webconsole/new-console-output/test/fixtures/stubs.js
@@ -28,6 +28,7 @@ exports.stubConsoleMessages = new Map([
       repeatId: null,
       category: CATEGORY_WEBDEV,
       severity: SEVERITY_LOG,
+      stacktrace: undefined
     })
   ],
   [

--- a/devtools/client/webconsole/new-console-output/types.js
+++ b/devtools/client/webconsole/new-console-output/types.js
@@ -36,4 +36,5 @@ exports.ConsoleMessage = Immutable.Record({
   repeatId: null,
   category: "output",
   severity: "log",
+  stacktrace: null,
 });

--- a/devtools/client/webconsole/new-console-output/utils/messages.js
+++ b/devtools/client/webconsole/new-console-output/utils/messages.js
@@ -77,6 +77,7 @@ function transformPacket(packet) {
         messageText,
         category: CATEGORY_WEBDEV,
         severity: level,
+        stacktrace: message.stacktrace,
       });
     }
 

--- a/devtools/client/webconsole/webconsole.js
+++ b/devtools/client/webconsole/webconsole.js
@@ -539,6 +539,8 @@ WebConsoleFrame.prototype = {
     this.jsterm = new JSTerm(this);
     this.jsterm.init();
 
+    let toolbox = gDevTools.getToolbox(this.owner.target);
+
     if (this.NEW_CONSOLE_OUTPUT_ENABLED) {
       // @TODO Remove this once JSTerm is handled with React/Redux.
       this.window.jsterm = this.jsterm;
@@ -551,7 +553,7 @@ WebConsoleFrame.prototype = {
       this.outputNode.parentNode.appendChild(this.experimentalOutputNode);
       // @TODO Once the toolbox has been converted to React, see if passing
       // in JSTerm is still necessary.
-      this.newConsoleOutput = new this.window.NewConsoleOutput(this.experimentalOutputNode, this.jsterm);
+      this.newConsoleOutput = new this.window.NewConsoleOutput(this.experimentalOutputNode, this.jsterm, toolbox);
       console.log("Created newConsoleOutput", this.newConsoleOutput);
 
       let filterToolbar = doc.querySelector(".hud-console-filter-toolbar");
@@ -563,7 +565,6 @@ WebConsoleFrame.prototype = {
     this.jsterm.on("sidebar-opened", this.resize);
     this.jsterm.on("sidebar-closed", this.resize);
 
-    let toolbox = gDevTools.getToolbox(this.owner.target);
     if (toolbox) {
       toolbox.on("webconsole-selected", this._onPanelSelected);
     }


### PR DESCRIPTION
Show stacktrace using StackTrace React component
Added a CSS rule for `open` stacktrace (class instead of attribute)
There's no test ( @linclark said it could land without them for now https://github.com/devtools-html/gecko-dev/issues/66#issuecomment-236186288)

Fixes #66
