### PR TITLE
Use require-hacker to load mocks in npm tests

### DIFF
--- a/devtools/client/webconsole/new-console-output/store.js
+++ b/devtools/client/webconsole/new-console-output/store.js
@@ -7,12 +7,9 @@ const {FilterState} = require("devtools/client/webconsole/new-console-output/red
 const {PrefState} = require("devtools/client/webconsole/new-console-output/reducers/prefs");
 const { combineReducers, createStore } = require("devtools/client/shared/vendor/redux");
 const { reducers } = require("./reducers/index");
+const Services = require("Services");
 
-function configureStore(Services) {
-  if (!Services) {
-    Services = require("Services");
-  }
-
+function configureStore() {
   const initialState = {
     prefs: new PrefState({
       logLimit: Math.max(Services.prefs.getIntPref("devtools.hud.loglimit"), 1),

--- a/devtools/client/webconsole/new-console-output/test/components/filter-bar.test.js
+++ b/devtools/client/webconsole/new-console-output/test/components/filter-bar.test.js
@@ -2,8 +2,8 @@
    http://creativecommons.org/publicdomain/zero/1.0/ */
 "use strict";
 
-// Require helper is necessary to load certain modules.
-require("devtools/client/webconsole/new-console-output/test/requireHelper")();
+const expect = require("expect");
+const sinon = require("sinon");
 const { render, mount } = require("enzyme");
 
 const { createFactory } = require("devtools/client/shared/vendor/react");
@@ -18,9 +18,6 @@ const {
 } = require("devtools/client/webconsole/new-console-output/constants");
 
 const { setupStore } = require("devtools/client/webconsole/new-console-output/test/helpers");
-
-const expect = require("expect");
-const sinon = require("sinon");
 
 describe("FilterBar component:", () => {
   it("initial render", () => {

--- a/devtools/client/webconsole/new-console-output/test/components/filter-button.test.js
+++ b/devtools/client/webconsole/new-console-output/test/components/filter-button.test.js
@@ -2,8 +2,8 @@
    http://creativecommons.org/publicdomain/zero/1.0/ */
 "use strict";
 
-// Require helper is necessary to load certain modules.
-require("devtools/client/webconsole/new-console-output/test/requireHelper")();
+const expect = require("expect");
+const sinon = require("sinon");
 const { render, shallow } = require("enzyme");
 
 const { createFactory } = require("devtools/client/shared/vendor/react");
@@ -13,9 +13,6 @@ const {
   FILTER_TOGGLE,
   MESSAGE_LEVEL
 } = require("devtools/client/webconsole/new-console-output/constants");
-
-const expect = require("expect");
-const sinon = require("sinon");
 
 describe("FilterButton component:", () => {
   const props = {

--- a/devtools/client/webconsole/new-console-output/test/fixtures/L10n.js
+++ b/devtools/client/webconsole/new-console-output/test/fixtures/L10n.js
@@ -4,12 +4,14 @@
 "use strict";
 
 // @TODO Load the actual strings from webconsole.properties instead.
-module.exports = {
-  getStr: str => {
+class L10n {
+  getStr(str) {
     switch (str) {
       case "severity.error":
         return "Error";
     }
     return str;
   }
-};
+}
+
+module.exports = L10n;

--- a/devtools/client/webconsole/new-console-output/test/fixtures/WebConsoleUtils.js
+++ b/devtools/client/webconsole/new-console-output/test/fixtures/WebConsoleUtils.js
@@ -1,0 +1,14 @@
+/* Any copyright is dedicated to the Public Domain.
+   http://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+const L10n = require("devtools/client/webconsole/new-console-output/test/fixtures/l10n");
+
+const Utils = {
+  L10n
+};
+
+module.exports = {
+  Utils
+};

--- a/devtools/client/webconsole/new-console-output/test/helpers.js
+++ b/devtools/client/webconsole/new-console-output/test/helpers.js
@@ -3,8 +3,6 @@
 
 "use strict";
 
-require("devtools/client/webconsole/new-console-output/test/requireHelper")();
-
 let ReactDOM = require("devtools/client/shared/vendor/react-dom");
 let React = require("devtools/client/shared/vendor/react");
 var TestUtils = React.addons.TestUtils;
@@ -13,7 +11,6 @@ const actions = require("devtools/client/webconsole/new-console-output/actions/m
 const { configureStore } = require("devtools/client/webconsole/new-console-output/store");
 const { IdGenerator } = require("devtools/client/webconsole/new-console-output/utils/id-generator");
 const { stubConsoleMessages } = require("devtools/client/webconsole/new-console-output/test/fixtures/stubs");
-const Services = require("devtools/client/webconsole/new-console-output/test/fixtures/Services");
 
 /**
  * Prepare actions for use in testing.
@@ -35,8 +32,7 @@ function setupActions() {
  * Prepare the store for use in testing.
  */
 function setupStore(input) {
-  // Inject the Services stub.
-  const store = configureStore(Services);
+  const store = configureStore();
 
   // Add the messages from the input commands to the store.
   input.forEach((cmd) => {

--- a/devtools/client/webconsole/new-console-output/test/requireHelper.js
+++ b/devtools/client/webconsole/new-console-output/test/requireHelper.js
@@ -4,23 +4,29 @@
 
 const requireHacker = require("require-hacker");
 
-module.exports = () => {
-  try {
-    requireHacker.global_hook("default", path => {
-      switch (path) {
-        case "react-dom/server":
-          return `const React = require('react-dev'); module.exports = React`;
-        case "react-addons-test-utils":
-          return `const React = require('react-dev'); module.exports = React.addons.TestUtils`;
-        case "react":
-          return `const React = require('react-dev'); module.exports = React`;
-        case "devtools/client/shared/vendor/react":
-          return `const React = require('react-dev'); module.exports = React`;
-        case "devtools/client/shared/vendor/react.default":
-          return `const React = require('react-dev'); module.exports = React`;
-      }
-    });
-  } catch (e) {
-    // Do nothing. This means the hook is already registered.
+requireHacker.global_hook("default", path => {
+  switch (path) {
+    // For Enzyme
+    case "react-dom/server":
+      return `const React = require('react-dev'); module.exports = React`;
+    case "react-addons-test-utils":
+      return `const React = require('react-dev'); module.exports = React.addons.TestUtils`;
+    // Use react-dev. This would be handled by browserLoader in Firefox.
+    case "react":
+    case "devtools/client/shared/vendor/react":
+      return `const React = require('react-dev'); module.exports = React`;
+    // For Rep's use of AMD
+    case "devtools/client/shared/vendor/react.default":
+      return `const React = require('react-dev'); module.exports = React`;
   }
-};
+
+  // Some modules depend on Chrome APIs which don't work in mocha. When such a module
+  // is required, replace it with a mock version.
+  switch (path) {
+    case "devtools/shared/webconsole/utils":
+      return `module.exports = require("devtools/client/webconsole/new-console-output/test/fixtures/WebConsoleUtils")`;
+    case "Services":
+    case "Services.default":
+      return `module.exports = require("devtools/client/webconsole/new-console-output/test/fixtures/Services")`;
+  }
+});

--- a/devtools/client/webconsole/new-console-output/utils/messages.js
+++ b/devtools/client/webconsole/new-console-output/utils/messages.js
@@ -6,14 +6,9 @@
 
 "use strict";
 
-let l10n;
-try {
-  const WebConsoleUtils = require("devtools/shared/webconsole/utils").Utils;
-  const STRINGS_URI = "chrome://devtools/locale/webconsole.properties";
-  l10n = new WebConsoleUtils.L10n(STRINGS_URI);
-} catch (e) {
-  l10n = require("devtools/client/webconsole/new-console-output/test/fixtures/l10n");
-}
+const WebConsoleUtils = require("devtools/shared/webconsole/utils").Utils;
+const STRINGS_URI = "chrome://devtools/locale/webconsole.properties";
+const l10n = new WebConsoleUtils.L10n(STRINGS_URI);
 
 const {
   MESSAGE_SOURCE,

--- a/devtools/client/webconsole/package.json
+++ b/devtools/client/webconsole/package.json
@@ -14,6 +14,6 @@
     "sinon": "^1.17.5"
   },
   "scripts": {
-    "test": "NODE_PATH=`pwd`/../../../:`pwd`/../../../devtools/client/shared/vendor/ mocha new-console-output/test/**/*.test.js --compilers js:babel-register -r jsdom-global/register"
+    "test": "NODE_PATH=`pwd`/../../../:`pwd`/../../../devtools/client/shared/vendor/ mocha new-console-output/test/**/*.test.js --compilers js:babel-register -r jsdom-global/register -r ./new-console-output/test/requireHelper.js"
   }
 }


### PR DESCRIPTION
Fixes #186 

This depends on #187
## Testing instructions
1. `npm i` to update `mocha-test-require-hacker`
2. `npm test`... no whammies
