### PR TITLE
wip - add mochitest-browser for new console frontend

### DIFF
--- a/devtools/client/webconsole/new-console-output/components/console-output.js
+++ b/devtools/client/webconsole/new-console-output/components/console-output.js
@@ -19,9 +19,7 @@ const ConsoleOutput = createClass({
 
   propTypes: {
     jsterm: PropTypes.object.isRequired,
-    // This function is created in mergeProps
-    openVariablesView: PropTypes.func.isRequired,
-    messages: PropTypes.array.isRequired
+    messages: PropTypes.object.isRequired
   },
 
   displayName: "ConsoleOutput",

--- a/devtools/client/webconsole/new-console-output/test/mochitest/browser.ini
+++ b/devtools/client/webconsole/new-console-output/test/mochitest/browser.ini
@@ -1,0 +1,9 @@
+[DEFAULT]
+tags = devtools
+subsuite = devtools
+support-files =
+  head.js
+  !/devtools/client/framework/test/shared-head.js
+  test-console.html
+
+[browser_webconsole_init.js]

--- a/devtools/client/webconsole/new-console-output/test/mochitest/browser_webconsole_init.js
+++ b/devtools/client/webconsole/new-console-output/test/mochitest/browser_webconsole_init.js
@@ -1,0 +1,23 @@
+/* -*- indent-tabs-mode: nil; js-indent-level: 2 -*- */
+/* vim: set ft=javascript ts=2 et sw=2 tw=80: */
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+const TEST_URI = "http://example.com/browser/devtools/client/webconsole/new-console-output/test/mochitest/test-console.html";
+
+add_task(function* () {
+  let toolbox = yield openNewTabAndToolbox(TEST_URI, "webconsole");
+  let ui = toolbox.getCurrentPanel().hud.ui;
+
+  ok(ui.jsterm, "jsterm exists");
+  ok(ui.newConsoleOutput, "newConsoleOutput exists");
+
+  // @TODO: fix proptype errors and actually emit 'new-messages' event
+  // let receivedLog = ui.once("new-messages");
+  // yield ContentTask.spawn(gBrowser.selectedBrowser, {}, function() {
+  //   content.wrappedJSObject.doLogs();
+  // });
+  // yield receivedLog;
+});

--- a/devtools/client/webconsole/new-console-output/test/mochitest/head.js
+++ b/devtools/client/webconsole/new-console-output/test/mochitest/head.js
@@ -1,0 +1,18 @@
+/* -*- indent-tabs-mode: nil; js-indent-level: 2 -*- */
+/* vim: set ft=javascript ts=2 et sw=2 tw=80: */
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+/* import-globals-from ../../../../framework/test/shared-head.js */
+
+"use strict";
+
+// shared-head.js handles imports, constants, and utility functions
+// Load the shared-head file first.
+Services.scriptloader.loadSubScript(
+  "chrome://mochitests/content/browser/devtools/client/framework/test/shared-head.js",
+  this);
+
+Services.prefs.setBoolPref("devtools.webconsole.new-frontend-enabled", true);
+registerCleanupFunction(() => {
+  Services.prefs.clearUserPref("devtools.webconsole.new-frontend-enabled");
+});

--- a/devtools/client/webconsole/new-console-output/test/mochitest/test-console.html
+++ b/devtools/client/webconsole/new-console-output/test/mochitest/test-console.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Simple webconsole test page</title>
+  </head>
+  <body>
+    <p>Simple webconsole test page</p>
+    <script>
+      function doLogs(num) {
+        num = num || 1;
+        for (var i = 0; i < num; i++) {
+          console.log(i);
+        }
+      }
+    </script>
+  </body>
+</html>

--- a/devtools/client/webconsole/new-console-output/test/moz.build
+++ b/devtools/client/webconsole/new-console-output/test/moz.build
@@ -3,6 +3,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+BROWSER_CHROME_MANIFESTS += ['mochitest/browser.ini']
+
 DIRS += [
     'fixtures'
 ]


### PR DESCRIPTION
Will fix #192 when it's done
## Testing instructions
1. `./mach mochitest devtools/client/webconsole/new-console-output/test/mochitest/browser_webconsole_init.js`

@linclark I'm still working through getting the new-messages event to emit, but in the mean time just a heads up that these are failing due to:
- INFO TEST-UNEXPECTED-FAIL | devtools/client/webconsole/new-console-output/test/mochitest/browser_webconsole_init.js | Warning: Failed propType: Required prop `openVariablesView` was not specified in `ConsoleOutput`. Check the render method of `Connect(ConsoleOutput)`.
- INFO TEST-UNEXPECTED-FAIL | devtools/client/webconsole/new-console-output/test/mochitest/browser_webconsole_init.js | Warning: Failed propType: Invalid prop `messages` of type `object` supplied to `ConsoleOutput`, expected `array`. Check the render method of `Connect(ConsoleOutput)`.
- INFO TEST-UNEXPECTED-FAIL | devtools/client/webconsole/new-console-output/test/mochitest/browser_webconsole_init.js | Warning: Failed propType: Invalid prop `grip` of type `number` supplied to `GripMessageBody`, expected `object`. Check the render method of `ConsoleApiCall`.
