### PR TITLE
Remove the URL tooltip when hovering VariableViewLink

### DIFF
--- a/devtools/client/webconsole/new-console-output/components/variables-view-link.js
+++ b/devtools/client/webconsole/new-console-output/components/variables-view-link.js
@@ -27,7 +27,6 @@ function VariablesViewLink(props) {
       onClick: openVariablesView.bind(null, object),
       className: "cm-variable",
       draggable: false,
-      href: "#"
     }, children)
   );
 }


### PR DESCRIPTION
Since this was fixed in https://bugzilla.mozilla.org/show_bug.cgi\?id\=1287389, we use
the same technique, i.e. removing the href attribute, that provides us what we want.

Fix #134
