### PR TITLE
Incorporate markup changes from network request stack trace changes (Bug 1281732) #107

### DIFF
--- a/devtools/client/webconsole/new-console-output/components/message-container.js
+++ b/devtools/client/webconsole/new-console-output/components/message-container.js
@@ -78,7 +78,7 @@ function getMessageComponent(message) {
         case MESSAGE_TYPE.LOG:
           return componentMap.get("PageError");
         default:
-          componentMap.get("DefaultRenderer");
+          return componentMap.get("DefaultRenderer");
       }
   }
 

--- a/devtools/client/webconsole/new-console-output/components/message-types/console-api-call.js
+++ b/devtools/client/webconsole/new-console-output/components/message-types/console-api-call.js
@@ -45,6 +45,15 @@ function ConsoleApiCall(props) {
 
   const icon = MessageIcon({level});
   const repeat = MessageRepeat({repeat: message.repeat});
+  const shouldRenderFrame = frame && frame.source !== "debugger eval code";
+  const location = dom.span({ className: "message-location devtools-monospace" },
+    shouldRenderFrame ? FrameView({
+      frame,
+      onClick: onViewSourceInDebugger,
+      showEmptyPathAsHost: true,
+      sourceMapService
+    }) : null
+  );
 
   let collapse = "";
   let attachment = "";
@@ -83,7 +92,6 @@ function ConsoleApiCall(props) {
     classes.push("open");
   }
 
-  const shouldRenderFrame = frame && frame.source !== "debugger eval code";
   return dom.div({
     className: classes.join(" ")
   },
@@ -92,23 +100,14 @@ function ConsoleApiCall(props) {
     icon,
     collapse,
     dom.span({className: "message-body-wrapper"},
-      dom.span({},
-        dom.span({className: "message-flex-body"},
-          dom.span({className: "message-body devtools-monospace"},
-            messageBody
-          ),
-          repeat,
-          dom.span({ className: "message-location devtools-monospace" },
-            shouldRenderFrame ? FrameView({
-              frame,
-              onClick: onViewSourceInDebugger,
-              showEmptyPathAsHost: true,
-              sourceMapService
-            }) : null
-          )
+      dom.span({className: "message-flex-body"},
+        dom.span({className: "message-body devtools-monospace"},
+          messageBody
         ),
-        attachment
-      )
+        repeat,
+        location
+      ),
+      attachment
     )
   );
 }

--- a/devtools/client/webconsole/new-console-output/components/message-types/console-command.js
+++ b/devtools/client/webconsole/new-console-output/components/message-types/console-command.js
@@ -47,8 +47,12 @@ function ConsoleCommand(props) {
     // @TODO add timestamp
     // @TODO add indent if necessary
     icon,
-    dom.span({className: "message-body-wrapper message-body devtools-monospace"},
-      dom.span({}, message.messageText)
+    dom.span({ className: "message-body-wrapper" },
+      dom.span({ className: "message-flex-body" },
+        dom.span({ className: "message-body devtools-monospace" },
+          message.messageText
+        )
+      )
     )
   );
 }

--- a/devtools/client/webconsole/new-console-output/components/message-types/evaluation-result.js
+++ b/devtools/client/webconsole/new-console-output/components/message-types/evaluation-result.js
@@ -42,10 +42,11 @@ function EvaluationResult(props) {
     // @TODO add timestamp
     // @TODO add indent if needed with console.group
     icon,
-    dom.span(
-      {className: "message-body-wrapper message-body devtools-monospace"},
-      dom.span({},
-        GripMessageBody({grip: message.parameters})
+    dom.span({ className: "message-body-wrapper" },
+      dom.span({ className: "message-flex-body" },
+        dom.span({ className: "message-body devtools-monospace" },
+          GripMessageBody({grip: message.parameters})
+        )
       )
     )
   );

--- a/devtools/client/webconsole/new-console-output/components/message-types/page-error.js
+++ b/devtools/client/webconsole/new-console-output/components/message-types/page-error.js
@@ -12,6 +12,7 @@ const {
   DOM: dom,
   PropTypes
 } = require("devtools/client/shared/vendor/react");
+const FrameView = createFactory(require("devtools/client/shared/components/frame"));
 const MessageRepeat = createFactory(require("devtools/client/webconsole/new-console-output/components/message-repeat").MessageRepeat);
 const MessageIcon = createFactory(require("devtools/client/webconsole/new-console-output/components/message-icon").MessageIcon);
 
@@ -22,11 +23,20 @@ PageError.propTypes = {
 };
 
 function PageError(props) {
-  const { message } = props;
-  const {source, level} = message;
+  const { message, sourceMapService, onViewSourceInDebugger } = props;
+  const { source, level, frame } = message;
 
   const repeat = MessageRepeat({repeat: message.repeat});
   const icon = MessageIcon({level});
+  const shouldRenderFrame = frame && frame.source !== "debugger eval code";
+  const location = dom.span({ className: "message-location devtools-monospace" },
+    shouldRenderFrame ? FrameView({
+      frame,
+      onClick: onViewSourceInDebugger,
+      showEmptyPathAsHost: true,
+      sourceMapService
+    }) : null
+  );
 
   const classes = ["message"];
 

--- a/devtools/client/webconsole/new-console-output/components/message-types/page-error.js
+++ b/devtools/client/webconsole/new-console-output/components/message-types/page-error.js
@@ -42,13 +42,14 @@ function PageError(props) {
     className: classes.join(" ")
   },
     icon,
-    dom.span(
-      {className: "message-body-wrapper message-body devtools-monospace"},
-      dom.span({},
-        message.messageText
+    dom.span({ className: "message-body-wrapper" },
+      dom.span({ className: "message-flex-body" },
+        dom.span({ className: "message-body devtools-monospace" },
+          message.messageText
+        ),
+        repeat
       )
-    ),
-    repeat
+    )
   );
 }
 

--- a/devtools/client/webconsole/new-console-output/test/components/evaluation-result.test.js
+++ b/devtools/client/webconsole/new-console-output/test/components/evaluation-result.test.js
@@ -25,6 +25,6 @@ describe("EvaluationResult component:", () => {
 });
 
 function getMessageBody(rendered) {
-  const queryPath = "div.message.cm-s-mozilla span.message-body-wrapper.message-body.devtools-monospace";
+  const queryPath = "div.message span.message-body-wrapper span.message-body";
   return rendered.querySelector(queryPath);
 }

--- a/devtools/client/webconsole/new-console-output/test/components/page-error.test.js
+++ b/devtools/client/webconsole/new-console-output/test/components/page-error.test.js
@@ -23,6 +23,6 @@ describe("PageError component:", () => {
 });
 
 function getMessageBody(rendered) {
-  const queryPath = "div.message span.message-body-wrapper.message-body.devtools-monospace";
+  const queryPath = "div.message span.message-body-wrapper span.message-body";
   return rendered.querySelector(queryPath);
 }

--- a/devtools/client/webconsole/new-console-output/utils/messages.js
+++ b/devtools/client/webconsole/new-console-output/utils/messages.js
@@ -116,11 +116,18 @@ function transformPacket(packet) {
         level = MESSAGE_LEVEL.INFO;
       }
 
+      const frame = {
+        source: pageError.sourceName,
+        line: pageError.lineNumber,
+        column: pageError.columnNumber
+      };
+
       return new ConsoleMessage({
         source: MESSAGE_SOURCE.JAVASCRIPT,
         type: MESSAGE_TYPE.LOG,
         level,
         messageText: pageError.errorMessage,
+        frame,
       });
     }
 


### PR DESCRIPTION
Fixes #107. Use the same markup structure (`message`, `message-body-wrapper`, `message-flex-body`, `message-body`) for all types of messages.

I also added location to `PageError` messages (until now, they were only in `ConsoleAPICall`) in order to better test the new structure.

A good next step would be to factor the markup structure into a common component, as it is now duplicated across several places. The only variable part is the class list for the `message` element and the markup of the `message-body`. Everything else is common code.
