### PR TITLE
Use packet stubs to test store

### DIFF
--- a/devtools/client/webconsole/new-console-output/test/actions/messages.test.js
+++ b/devtools/client/webconsole/new-console-output/test/actions/messages.test.js
@@ -3,7 +3,7 @@
 "use strict";
 
 const { getRepeatId } = require("devtools/client/webconsole/new-console-output/utils/messages");
-const { stubConsoleMessages } = require("devtools/client/webconsole/new-console-output/test/fixtures/stubs/index");
+const { stubPreparedMessages } = require("devtools/client/webconsole/new-console-output/test/fixtures/stubs/index");
 const { setupActions } = require("devtools/client/webconsole/new-console-output/test/helpers");
 const constants = require("devtools/client/webconsole/new-console-output/constants");
 
@@ -44,7 +44,7 @@ describe("Message actions:", () => {
       const action = actions.messageAdd(packet);
       const expected = {
         type: constants.MESSAGE_ADD,
-        message: stubConsoleMessages.get("console.log('foobar', 'test')")
+        message: stubPreparedMessages.get("console.log('foobar', 'test')")
       };
 
       expect(action.message.toJS()).toEqual(expected.message.toJS());

--- a/devtools/client/webconsole/new-console-output/test/actions/messages.test.js
+++ b/devtools/client/webconsole/new-console-output/test/actions/messages.test.js
@@ -3,7 +3,7 @@
 "use strict";
 
 const { getRepeatId } = require("devtools/client/webconsole/new-console-output/utils/messages");
-const stubConsoleMessages = require("devtools/client/webconsole/new-console-output/test/fixtures/stubs/index");
+const { stubConsoleMessages } = require("devtools/client/webconsole/new-console-output/test/fixtures/stubs/index");
 const { setupActions } = require("devtools/client/webconsole/new-console-output/test/helpers");
 const constants = require("devtools/client/webconsole/new-console-output/constants");
 

--- a/devtools/client/webconsole/new-console-output/test/components/console-api-call.test.js
+++ b/devtools/client/webconsole/new-console-output/test/components/console-api-call.test.js
@@ -10,13 +10,13 @@ const { renderComponent } = require("devtools/client/webconsole/new-console-outp
 const { ConsoleApiCall } = require("devtools/client/webconsole/new-console-output/components/message-types/console-api-call");
 
 // Test fakes.
-const { stubConsoleMessages } = require("devtools/client/webconsole/new-console-output/test/fixtures/stubs/index");
+const { stubPreparedMessages } = require("devtools/client/webconsole/new-console-output/test/fixtures/stubs/index");
 const onViewSourceInDebugger = () => {};
 
 describe("ConsoleAPICall component:", () => {
   describe("console.log", () => {
     it("renders string grips", () => {
-      const message = stubConsoleMessages.get("console.log('foobar', 'test')");
+      const message = stubPreparedMessages.get("console.log('foobar', 'test')");
       const rendered = renderComponent(ConsoleApiCall, {message, onViewSourceInDebugger});
 
       const messageBody = getMessageBody(rendered);
@@ -28,7 +28,7 @@ describe("ConsoleAPICall component:", () => {
     });
     it("renders repeat node", () => {
       const message =
-        stubConsoleMessages.get("console.log('foobar', 'test')")
+        stubPreparedMessages.get("console.log('foobar', 'test')")
         .set("repeat", 107);
       const rendered = renderComponent(ConsoleApiCall, {message, onViewSourceInDebugger});
 
@@ -39,7 +39,7 @@ describe("ConsoleAPICall component:", () => {
 
   describe("console.count", () => {
     it("renders", () => {
-      const message = stubConsoleMessages.get("console.count('bar')");
+      const message = stubPreparedMessages.get("console.count('bar')");
       const rendered = renderComponent(ConsoleApiCall, {message, onViewSourceInDebugger});
 
       const messageBody = getMessageBody(rendered);
@@ -49,7 +49,7 @@ describe("ConsoleAPICall component:", () => {
 
   describe("console.time", () => {
     it("does not show anything", () => {
-      const message = stubConsoleMessages.get("console.time('bar')");
+      const message = stubPreparedMessages.get("console.time('bar')");
       const rendered = renderComponent(ConsoleApiCall, {message, onViewSourceInDebugger});
 
       const messageBody = getMessageBody(rendered);
@@ -59,7 +59,7 @@ describe("ConsoleAPICall component:", () => {
 
   describe("console.timeEnd", () => {
     it("renders as expected", () => {
-      const message = stubConsoleMessages.get("console.timeEnd('bar')");
+      const message = stubPreparedMessages.get("console.timeEnd('bar')");
       const rendered = renderComponent(ConsoleApiCall, {message, onViewSourceInDebugger});
 
       const messageBody = getMessageBody(rendered);

--- a/devtools/client/webconsole/new-console-output/test/components/console-api-call.test.js
+++ b/devtools/client/webconsole/new-console-output/test/components/console-api-call.test.js
@@ -10,7 +10,7 @@ const { renderComponent } = require("devtools/client/webconsole/new-console-outp
 const { ConsoleApiCall } = require("devtools/client/webconsole/new-console-output/components/message-types/console-api-call");
 
 // Test fakes.
-const stubConsoleMessages = require("devtools/client/webconsole/new-console-output/test/fixtures/stubs/index");
+const { stubConsoleMessages } = require("devtools/client/webconsole/new-console-output/test/fixtures/stubs/index");
 const onViewSourceInDebugger = () => {};
 
 describe("ConsoleAPICall component:", () => {

--- a/devtools/client/webconsole/new-console-output/test/components/evaluation-result.test.js
+++ b/devtools/client/webconsole/new-console-output/test/components/evaluation-result.test.js
@@ -2,7 +2,7 @@
    http://creativecommons.org/publicdomain/zero/1.0/ */
 "use strict";
 
-const { stubConsoleMessages } = require("devtools/client/webconsole/new-console-output/test/fixtures/stubs/index");
+const { stubPreparedMessages } = require("devtools/client/webconsole/new-console-output/test/fixtures/stubs/index");
 const { EvaluationResult } = require("devtools/client/webconsole/new-console-output/components/message-types/evaluation-result");
 
 const expect = require("expect");
@@ -13,7 +13,7 @@ const {
 
 describe("EvaluationResult component:", () => {
   it("renders a grip result", () => {
-    const message = stubConsoleMessages.get("new Date(0)");
+    const message = stubPreparedMessages.get("new Date(0)");
     const props = {
       message
     };

--- a/devtools/client/webconsole/new-console-output/test/components/evaluation-result.test.js
+++ b/devtools/client/webconsole/new-console-output/test/components/evaluation-result.test.js
@@ -2,7 +2,7 @@
    http://creativecommons.org/publicdomain/zero/1.0/ */
 "use strict";
 
-const stubConsoleMessages = require("devtools/client/webconsole/new-console-output/test/fixtures/stubs/index");
+const { stubConsoleMessages } = require("devtools/client/webconsole/new-console-output/test/fixtures/stubs/index");
 const { EvaluationResult } = require("devtools/client/webconsole/new-console-output/components/message-types/evaluation-result");
 
 const expect = require("expect");

--- a/devtools/client/webconsole/new-console-output/test/components/message-container.test.js
+++ b/devtools/client/webconsole/new-console-output/test/components/message-container.test.js
@@ -16,7 +16,7 @@ const { EvaluationResult } = require("devtools/client/webconsole/new-console-out
 const { PageError } = require("devtools/client/webconsole/new-console-output/components/message-types/page-error");
 
 // Test fakes.
-const stubConsoleMessages = require("devtools/client/webconsole/new-console-output/test/fixtures/stubs/index");
+const { stubConsoleMessages } = require("devtools/client/webconsole/new-console-output/test/fixtures/stubs/index");
 const onViewSourceInDebugger = () => {};
 
 describe("MessageContainer component:", () => {

--- a/devtools/client/webconsole/new-console-output/test/components/message-container.test.js
+++ b/devtools/client/webconsole/new-console-output/test/components/message-container.test.js
@@ -16,12 +16,12 @@ const { EvaluationResult } = require("devtools/client/webconsole/new-console-out
 const { PageError } = require("devtools/client/webconsole/new-console-output/components/message-types/page-error");
 
 // Test fakes.
-const { stubConsoleMessages } = require("devtools/client/webconsole/new-console-output/test/fixtures/stubs/index");
+const { stubPreparedMessages } = require("devtools/client/webconsole/new-console-output/test/fixtures/stubs/index");
 const onViewSourceInDebugger = () => {};
 
 describe("MessageContainer component:", () => {
   it("pipes data to children as expected", () => {
-    const message = stubConsoleMessages.get("console.log('foobar', 'test')");
+    const message = stubPreparedMessages.get("console.log('foobar', 'test')");
     const rendered = renderComponent(MessageContainer, {message, onViewSourceInDebugger});
 
     expect(rendered.textContent.includes("foobar")).toBe(true);
@@ -30,15 +30,15 @@ describe("MessageContainer component:", () => {
     const messageTypes = [
       {
         component: ConsoleApiCall,
-        message: stubConsoleMessages.get("console.log('foobar', 'test')")
+        message: stubPreparedMessages.get("console.log('foobar', 'test')")
       },
       {
         component: EvaluationResult,
-        message: stubConsoleMessages.get("new Date(0)")
+        message: stubPreparedMessages.get("new Date(0)")
       },
       {
         component: PageError,
-        message: stubConsoleMessages.get("ReferenceError: asdf is not defined")
+        message: stubPreparedMessages.get("ReferenceError: asdf is not defined")
       }
     ];
 

--- a/devtools/client/webconsole/new-console-output/test/components/page-error.test.js
+++ b/devtools/client/webconsole/new-console-output/test/components/page-error.test.js
@@ -2,7 +2,7 @@
    http://creativecommons.org/publicdomain/zero/1.0/ */
 "use strict";
 
-const stubConsoleMessages = require("devtools/client/webconsole/new-console-output/test/fixtures/stubs/index");
+const { stubConsoleMessages } = require("devtools/client/webconsole/new-console-output/test/fixtures/stubs/index");
 
 const { PageError } = require("devtools/client/webconsole/new-console-output/components/message-types/page-error");
 

--- a/devtools/client/webconsole/new-console-output/test/components/page-error.test.js
+++ b/devtools/client/webconsole/new-console-output/test/components/page-error.test.js
@@ -2,7 +2,7 @@
    http://creativecommons.org/publicdomain/zero/1.0/ */
 "use strict";
 
-const { stubConsoleMessages } = require("devtools/client/webconsole/new-console-output/test/fixtures/stubs/index");
+const { stubPreparedMessages } = require("devtools/client/webconsole/new-console-output/test/fixtures/stubs/index");
 
 const { PageError } = require("devtools/client/webconsole/new-console-output/components/message-types/page-error");
 
@@ -14,7 +14,7 @@ const {
 
 describe("PageError component:", () => {
   it("renders a page error", () => {
-    const message = stubConsoleMessages.get("ReferenceError: asdf is not defined");
+    const message = stubPreparedMessages.get("ReferenceError: asdf is not defined");
     const rendered = renderComponent(PageError, {message});
 
     const messageBody = getMessageBody(rendered);

--- a/devtools/client/webconsole/new-console-output/test/fixtures/L10n.js
+++ b/devtools/client/webconsole/new-console-output/test/fixtures/L10n.js
@@ -9,6 +9,8 @@ class L10n {
     switch (str) {
       case "level.error":
         return "Error";
+      case "consoleCleared":
+        return "Console was cleared.";
     }
     return str;
   }

--- a/devtools/client/webconsole/new-console-output/test/fixtures/stub-generators/browser_webconsole_update_stubs_console_api.js
+++ b/devtools/client/webconsole/new-console-output/test/fixtures/stub-generators/browser_webconsole_update_stubs_console_api.js
@@ -10,7 +10,10 @@ const { consoleApi: snippets } = require("devtools/client/webconsole/new-console
 
 const TEST_URI = "http://example.com/browser/devtools/client/webconsole/new-console-output/test/fixtures/stub-generators/test-console-api.html";
 
-let stubs = [];
+let stubs = {
+  preparedMessages: [],
+  packets: [],
+};
 
 add_task(function* () {
   let tempFilePath = OS.Path.join(`${BASE_PATH}/stub-generators`, "test-tempfile.js");
@@ -26,7 +29,8 @@ add_task(function* () {
     let received = new Promise(resolve => {
       let i = 0;
       toolbox.target.client.addListener("consoleAPICall", (type, res) => {
-        stubs.push(formatStub(keys[i], res));
+        stubs.packets.push(formatPacket(keys[i], res));
+        stubs.preparedMessages.push(formatStub(keys[i], res));
         if(++i === keys.length ){
           resolve();
         }

--- a/devtools/client/webconsole/new-console-output/test/fixtures/stub-generators/browser_webconsole_update_stubs_evaluation_result.js
+++ b/devtools/client/webconsole/new-console-output/test/fixtures/stub-generators/browser_webconsole_update_stubs_evaluation_result.js
@@ -10,18 +10,23 @@ const TEST_URI = "data:text/html;charset=utf-8,stub generation";
 
 const { evaluationResult: snippets} = require("devtools/client/webconsole/new-console-output/test/fixtures/stub-generators/stub-snippets.js");
 
-let stubs = [];
+let stubs = {
+  preparedMessages: [],
+  packets: [],
+};
 
 add_task(function* () {
   let toolbox = yield openNewTabAndToolbox(TEST_URI, "webconsole");
   ok(true, "make the test not fail");
 
   for (var [code,key] of snippets) {
+    let i = 0;
     const packet = yield new Promise(resolve => {
       toolbox.target.activeConsole.evaluateJS(code, resolve);
     });
-    stubs.push(formatStub(key, packet));
-    if (stubs.length == snippets.size) {
+    stubs.packets.push(formatPacket(key, packet));
+    stubs.preparedMessages.push(formatStub(key, packet));
+    if (++i == snippets.size) {
       let filePath = OS.Path.join(`${BASE_PATH}/stubs`, "evaluationResult.js");
       OS.File.writeAtomic(filePath, formatFile(stubs));
     }

--- a/devtools/client/webconsole/new-console-output/test/fixtures/stub-generators/browser_webconsole_update_stubs_evaluation_result.js
+++ b/devtools/client/webconsole/new-console-output/test/fixtures/stub-generators/browser_webconsole_update_stubs_evaluation_result.js
@@ -20,15 +20,13 @@ add_task(function* () {
   ok(true, "make the test not fail");
 
   for (var [code,key] of snippets) {
-    let i = 0;
     const packet = yield new Promise(resolve => {
       toolbox.target.activeConsole.evaluateJS(code, resolve);
     });
     stubs.packets.push(formatPacket(key, packet));
     stubs.preparedMessages.push(formatStub(key, packet));
-    if (++i == snippets.size) {
-      let filePath = OS.Path.join(`${BASE_PATH}/stubs`, "evaluationResult.js");
-      OS.File.writeAtomic(filePath, formatFile(stubs));
-    }
   }
+
+  let filePath = OS.Path.join(`${BASE_PATH}/stubs`, "evaluationResult.js");
+  OS.File.writeAtomic(filePath, formatFile(stubs));
 });

--- a/devtools/client/webconsole/new-console-output/test/fixtures/stub-generators/browser_webconsole_update_stubs_page_error.js
+++ b/devtools/client/webconsole/new-console-output/test/fixtures/stub-generators/browser_webconsole_update_stubs_page_error.js
@@ -10,7 +10,10 @@ const TEST_URI = "data:text/html;charset=utf-8,stub generation";
 
 const { pageError: snippets} = require("devtools/client/webconsole/new-console-output/test/fixtures/stub-generators/stub-snippets.js");
 
-let stubs = [];
+let stubs = {
+  preparedMessages: [],
+  packets: [],
+};
 
 add_task(function* () {
   let toolbox = yield openNewTabAndToolbox(TEST_URI, "webconsole");
@@ -23,7 +26,8 @@ add_task(function* () {
         info("Received page error:" + e + " " + JSON.stringify(packet, null, "\t"));
 
         let message = prepareMessage(packet, {getNextId: () => 1});
-        stubs.push(formatStub(message.messageText, packet));
+        stubs.packets.push(formatPacket(message.messageText, packet));
+        stubs.preparedMessages.push(formatStub(message.messageText, packet));
         resolve();
       });
     });

--- a/devtools/client/webconsole/new-console-output/test/fixtures/stub-generators/head.js
+++ b/devtools/client/webconsole/new-console-output/test/fixtures/stub-generators/head.js
@@ -21,6 +21,12 @@ const { prepareMessage } = require("devtools/client/webconsole/new-console-outpu
 
 const BASE_PATH = "../../../../devtools/client/webconsole/new-console-output/test/fixtures";
 
+function formatPacket(key, packet) {
+  return `
+stubPackets.set("${key}", ${JSON.stringify(packet, null, "\t")});
+`;
+}
+
 function formatStub(key, message) {
   let prepared = prepareMessage(message, {getNextId: () => "1"});
   return `
@@ -41,7 +47,13 @@ function formatFile(stubs) {
 const { ConsoleMessage } = require("devtools/client/webconsole/new-console-output/types");
 
 let stubConsoleMessages = new Map();
-${stubs.join("")}
+let stubPackets = new Map();
 
-module.exports = stubConsoleMessages`;
+${stubs.preparedMessages.join("")}
+${stubs.packets.join("")}
+
+module.exports = {
+  stubConsoleMessages,
+  stubPackets,
+}`;
 }

--- a/devtools/client/webconsole/new-console-output/test/fixtures/stub-generators/head.js
+++ b/devtools/client/webconsole/new-console-output/test/fixtures/stub-generators/head.js
@@ -30,7 +30,7 @@ stubPackets.set("${key}", ${JSON.stringify(packet, null, "\t")});
 function formatStub(key, message) {
   let prepared = prepareMessage(message, {getNextId: () => "1"});
   return `
-stubConsoleMessages.set("${key}", new ConsoleMessage(${JSON.stringify(prepared, null, "\t")}));
+stubPreparedMessages.set("${key}", new ConsoleMessage(${JSON.stringify(prepared, null, "\t")}));
 `;
 }
 
@@ -46,14 +46,14 @@ function formatFile(stubs) {
 
 const { ConsoleMessage } = require("devtools/client/webconsole/new-console-output/types");
 
-let stubConsoleMessages = new Map();
+let stubPreparedMessages = new Map();
 let stubPackets = new Map();
 
 ${stubs.preparedMessages.join("")}
 ${stubs.packets.join("")}
 
 module.exports = {
-  stubConsoleMessages,
+  stubPreparedMessages,
   stubPackets,
 }`;
 }

--- a/devtools/client/webconsole/new-console-output/test/fixtures/stubs/consoleApi.js
+++ b/devtools/client/webconsole/new-console-output/test/fixtures/stubs/consoleApi.js
@@ -10,6 +10,8 @@
 const { ConsoleMessage } = require("devtools/client/webconsole/new-console-output/types");
 
 let stubConsoleMessages = new Map();
+let stubPackets = new Map();
+
 
 stubConsoleMessages.set("console.log('foobar', 'test')", new ConsoleMessage({
 	"id": "1",
@@ -220,10 +222,10 @@ stubConsoleMessages.set("console.timeEnd('bar')", new ConsoleMessage({
 	"source": "console-api",
 	"type": "timeEnd",
 	"level": "log",
-	"messageText": "bar: 3.87ms",
+	"messageText": "bar: 2.01ms",
 	"parameters": null,
 	"repeat": 1,
-	"repeatId": "{\"id\":null,\"allowRepeating\":true,\"source\":\"console-api\",\"type\":\"timeEnd\",\"level\":\"log\",\"messageText\":\"bar: 3.87ms\",\"parameters\":null,\"repeatId\":null,\"stacktrace\":null,\"frame\":{\"source\":\"http://example.com/browser/devtools/client/webconsole/new-console-output/test/fixtures/stub-generators/test-tempfile.js\",\"line\":3,\"column\":1}}",
+	"repeatId": "{\"id\":null,\"allowRepeating\":true,\"source\":\"console-api\",\"type\":\"timeEnd\",\"level\":\"log\",\"messageText\":\"bar: 2.01ms\",\"parameters\":null,\"repeatId\":null,\"stacktrace\":null,\"frame\":{\"source\":\"http://example.com/browser/devtools/client/webconsole/new-console-output/test/fixtures/stub-generators/test-tempfile.js\",\"line\":3,\"column\":1}}",
 	"stacktrace": null,
 	"frame": {
 		"source": "http://example.com/browser/devtools/client/webconsole/new-console-output/test/fixtures/stub-generators/test-tempfile.js",
@@ -233,4 +235,353 @@ stubConsoleMessages.set("console.timeEnd('bar')", new ConsoleMessage({
 }));
 
 
-module.exports = stubConsoleMessages
+stubPackets.set("console.log('foobar', 'test')", {
+	"from": "server1.conn0.child1/consoleActor2",
+	"type": "consoleAPICall",
+	"message": {
+		"arguments": [
+			"foobar",
+			"test"
+		],
+		"columnNumber": 27,
+		"counter": null,
+		"filename": "http://example.com/browser/devtools/client/webconsole/new-console-output/test/fixtures/stub-generators/test-tempfile.js",
+		"functionName": "triggerPacket",
+		"groupName": "",
+		"level": "log",
+		"lineNumber": 1,
+		"originAttributes": {
+			"addonId": "",
+			"appId": 0,
+			"inIsolatedMozBrowser": false,
+			"privateBrowsingId": 0,
+			"signedPkg": "",
+			"userContextId": 0
+		},
+		"private": false,
+		"styles": [],
+		"timeStamp": 1471885545204,
+		"timer": null,
+		"workerType": "none",
+		"category": "webdev"
+	}
+});
+
+stubPackets.set("console.log(undefined)", {
+	"from": "server1.conn1.child1/consoleActor2",
+	"type": "consoleAPICall",
+	"message": {
+		"arguments": [
+			{
+				"type": "undefined"
+			}
+		],
+		"columnNumber": 27,
+		"counter": null,
+		"filename": "http://example.com/browser/devtools/client/webconsole/new-console-output/test/fixtures/stub-generators/test-tempfile.js",
+		"functionName": "triggerPacket",
+		"groupName": "",
+		"level": "log",
+		"lineNumber": 1,
+		"originAttributes": {
+			"addonId": "",
+			"appId": 0,
+			"inIsolatedMozBrowser": false,
+			"privateBrowsingId": 0,
+			"signedPkg": "",
+			"userContextId": 0
+		},
+		"private": false,
+		"styles": [],
+		"timeStamp": 1471885546075,
+		"timer": null,
+		"workerType": "none",
+		"category": "webdev"
+	}
+});
+
+stubPackets.set("console.warn('danger, will robinson!')", {
+	"from": "server1.conn2.child1/consoleActor2",
+	"type": "consoleAPICall",
+	"message": {
+		"arguments": [
+			"danger, will robinson!"
+		],
+		"columnNumber": 27,
+		"counter": null,
+		"filename": "http://example.com/browser/devtools/client/webconsole/new-console-output/test/fixtures/stub-generators/test-tempfile.js",
+		"functionName": "triggerPacket",
+		"groupName": "",
+		"level": "warn",
+		"lineNumber": 1,
+		"originAttributes": {
+			"addonId": "",
+			"appId": 0,
+			"inIsolatedMozBrowser": false,
+			"privateBrowsingId": 0,
+			"signedPkg": "",
+			"userContextId": 0
+		},
+		"private": false,
+		"styles": [],
+		"timeStamp": 1471885546795,
+		"timer": null,
+		"workerType": "none",
+		"category": "webdev"
+	}
+});
+
+stubPackets.set("console.log(NaN)", {
+	"from": "server1.conn3.child1/consoleActor2",
+	"type": "consoleAPICall",
+	"message": {
+		"arguments": [
+			{
+				"type": "NaN"
+			}
+		],
+		"columnNumber": 27,
+		"counter": null,
+		"filename": "http://example.com/browser/devtools/client/webconsole/new-console-output/test/fixtures/stub-generators/test-tempfile.js",
+		"functionName": "triggerPacket",
+		"groupName": "",
+		"level": "log",
+		"lineNumber": 1,
+		"originAttributes": {
+			"addonId": "",
+			"appId": 0,
+			"inIsolatedMozBrowser": false,
+			"privateBrowsingId": 0,
+			"signedPkg": "",
+			"userContextId": 0
+		},
+		"private": false,
+		"styles": [],
+		"timeStamp": 1471885547605,
+		"timer": null,
+		"workerType": "none",
+		"category": "webdev"
+	}
+});
+
+stubPackets.set("console.log(null)", {
+	"from": "server1.conn4.child1/consoleActor2",
+	"type": "consoleAPICall",
+	"message": {
+		"arguments": [
+			{
+				"type": "null"
+			}
+		],
+		"columnNumber": 27,
+		"counter": null,
+		"filename": "http://example.com/browser/devtools/client/webconsole/new-console-output/test/fixtures/stub-generators/test-tempfile.js",
+		"functionName": "triggerPacket",
+		"groupName": "",
+		"level": "log",
+		"lineNumber": 1,
+		"originAttributes": {
+			"addonId": "",
+			"appId": 0,
+			"inIsolatedMozBrowser": false,
+			"privateBrowsingId": 0,
+			"signedPkg": "",
+			"userContextId": 0
+		},
+		"private": false,
+		"styles": [],
+		"timeStamp": 1471885548414,
+		"timer": null,
+		"workerType": "none",
+		"category": "webdev"
+	}
+});
+
+stubPackets.set("console.clear()", {
+	"from": "server1.conn5.child1/consoleActor2",
+	"type": "consoleAPICall",
+	"message": {
+		"arguments": [],
+		"columnNumber": 27,
+		"counter": null,
+		"filename": "http://example.com/browser/devtools/client/webconsole/new-console-output/test/fixtures/stub-generators/test-tempfile.js",
+		"functionName": "triggerPacket",
+		"groupName": "",
+		"level": "clear",
+		"lineNumber": 1,
+		"originAttributes": {
+			"addonId": "",
+			"appId": 0,
+			"inIsolatedMozBrowser": false,
+			"privateBrowsingId": 0,
+			"signedPkg": "",
+			"userContextId": 0
+		},
+		"private": false,
+		"timeStamp": 1471885549077,
+		"timer": null,
+		"workerType": "none",
+		"styles": [],
+		"category": "webdev"
+	}
+});
+
+stubPackets.set("console.count('bar')", {
+	"from": "server1.conn6.child1/consoleActor2",
+	"type": "consoleAPICall",
+	"message": {
+		"arguments": [
+			"bar"
+		],
+		"columnNumber": 27,
+		"counter": {
+			"count": 1,
+			"label": "bar"
+		},
+		"filename": "http://example.com/browser/devtools/client/webconsole/new-console-output/test/fixtures/stub-generators/test-tempfile.js",
+		"functionName": "triggerPacket",
+		"groupName": "",
+		"level": "count",
+		"lineNumber": 1,
+		"originAttributes": {
+			"addonId": "",
+			"appId": 0,
+			"inIsolatedMozBrowser": false,
+			"privateBrowsingId": 0,
+			"signedPkg": "",
+			"userContextId": 0
+		},
+		"private": false,
+		"timeStamp": 1471885549791,
+		"timer": null,
+		"workerType": "none",
+		"styles": [],
+		"category": "webdev"
+	}
+});
+
+stubPackets.set("console.trace()", {
+	"from": "server1.conn7.child1/consoleActor2",
+	"type": "consoleAPICall",
+	"message": {
+		"arguments": [],
+		"columnNumber": 3,
+		"counter": null,
+		"filename": "http://example.com/browser/devtools/client/webconsole/new-console-output/test/fixtures/stub-generators/test-tempfile.js",
+		"functionName": "bar",
+		"groupName": "",
+		"level": "trace",
+		"lineNumber": 3,
+		"originAttributes": {
+			"addonId": "",
+			"appId": 0,
+			"inIsolatedMozBrowser": false,
+			"privateBrowsingId": 0,
+			"signedPkg": "",
+			"userContextId": 0
+		},
+		"private": false,
+		"timeStamp": 1471885551114,
+		"timer": null,
+		"stacktrace": [
+			{
+				"columnNumber": 3,
+				"filename": "http://example.com/browser/devtools/client/webconsole/new-console-output/test/fixtures/stub-generators/test-tempfile.js",
+				"functionName": "bar",
+				"language": 2,
+				"lineNumber": 3
+			},
+			{
+				"columnNumber": 3,
+				"filename": "http://example.com/browser/devtools/client/webconsole/new-console-output/test/fixtures/stub-generators/test-tempfile.js",
+				"functionName": "foo",
+				"language": 2,
+				"lineNumber": 6
+			},
+			{
+				"columnNumber": 1,
+				"filename": "http://example.com/browser/devtools/client/webconsole/new-console-output/test/fixtures/stub-generators/test-tempfile.js",
+				"functionName": "triggerPacket",
+				"language": 2,
+				"lineNumber": 9
+			}
+		],
+		"workerType": "none",
+		"styles": [],
+		"category": "webdev"
+	}
+});
+
+stubPackets.set("console.time('bar')", {
+	"from": "server1.conn8.child1/consoleActor2",
+	"type": "consoleAPICall",
+	"message": {
+		"arguments": [
+			"bar"
+		],
+		"columnNumber": 1,
+		"counter": null,
+		"filename": "http://example.com/browser/devtools/client/webconsole/new-console-output/test/fixtures/stub-generators/test-tempfile.js",
+		"functionName": "triggerPacket",
+		"groupName": "",
+		"level": "time",
+		"lineNumber": 2,
+		"originAttributes": {
+			"addonId": "",
+			"appId": 0,
+			"inIsolatedMozBrowser": false,
+			"privateBrowsingId": 0,
+			"signedPkg": "",
+			"userContextId": 0
+		},
+		"private": false,
+		"timeStamp": 1471885552201,
+		"timer": {
+			"name": "bar",
+			"started": 970.09
+		},
+		"workerType": "none",
+		"styles": [],
+		"category": "webdev"
+	}
+});
+
+stubPackets.set("console.timeEnd('bar')", {
+	"from": "server1.conn8.child1/consoleActor2",
+	"type": "consoleAPICall",
+	"message": {
+		"arguments": [
+			"bar"
+		],
+		"columnNumber": 1,
+		"counter": null,
+		"filename": "http://example.com/browser/devtools/client/webconsole/new-console-output/test/fixtures/stub-generators/test-tempfile.js",
+		"functionName": "triggerPacket",
+		"groupName": "",
+		"level": "timeEnd",
+		"lineNumber": 3,
+		"originAttributes": {
+			"addonId": "",
+			"appId": 0,
+			"inIsolatedMozBrowser": false,
+			"privateBrowsingId": 0,
+			"signedPkg": "",
+			"userContextId": 0
+		},
+		"private": false,
+		"timeStamp": 1471885552203,
+		"timer": {
+			"duration": 2.0149999999999864,
+			"name": "bar"
+		},
+		"workerType": "none",
+		"styles": [],
+		"category": "webdev"
+	}
+});
+
+
+module.exports = {
+  stubConsoleMessages,
+  stubPackets,
+}

--- a/devtools/client/webconsole/new-console-output/test/fixtures/stubs/consoleApi.js
+++ b/devtools/client/webconsole/new-console-output/test/fixtures/stubs/consoleApi.js
@@ -9,11 +9,11 @@
 
 const { ConsoleMessage } = require("devtools/client/webconsole/new-console-output/types");
 
-let stubConsoleMessages = new Map();
+let stubPreparedMessages = new Map();
 let stubPackets = new Map();
 
 
-stubConsoleMessages.set("console.log('foobar', 'test')", new ConsoleMessage({
+stubPreparedMessages.set("console.log('foobar', 'test')", new ConsoleMessage({
 	"id": "1",
 	"allowRepeating": true,
 	"source": "console-api",
@@ -34,7 +34,7 @@ stubConsoleMessages.set("console.log('foobar', 'test')", new ConsoleMessage({
 	}
 }));
 
-stubConsoleMessages.set("console.log(undefined)", new ConsoleMessage({
+stubPreparedMessages.set("console.log(undefined)", new ConsoleMessage({
 	"id": "1",
 	"allowRepeating": true,
 	"source": "console-api",
@@ -56,7 +56,7 @@ stubConsoleMessages.set("console.log(undefined)", new ConsoleMessage({
 	}
 }));
 
-stubConsoleMessages.set("console.warn('danger, will robinson!')", new ConsoleMessage({
+stubPreparedMessages.set("console.warn('danger, will robinson!')", new ConsoleMessage({
 	"id": "1",
 	"allowRepeating": true,
 	"source": "console-api",
@@ -76,7 +76,7 @@ stubConsoleMessages.set("console.warn('danger, will robinson!')", new ConsoleMes
 	}
 }));
 
-stubConsoleMessages.set("console.log(NaN)", new ConsoleMessage({
+stubPreparedMessages.set("console.log(NaN)", new ConsoleMessage({
 	"id": "1",
 	"allowRepeating": true,
 	"source": "console-api",
@@ -98,7 +98,7 @@ stubConsoleMessages.set("console.log(NaN)", new ConsoleMessage({
 	}
 }));
 
-stubConsoleMessages.set("console.log(null)", new ConsoleMessage({
+stubPreparedMessages.set("console.log(null)", new ConsoleMessage({
 	"id": "1",
 	"allowRepeating": true,
 	"source": "console-api",
@@ -120,7 +120,7 @@ stubConsoleMessages.set("console.log(null)", new ConsoleMessage({
 	}
 }));
 
-stubConsoleMessages.set("console.clear()", new ConsoleMessage({
+stubPreparedMessages.set("console.clear()", new ConsoleMessage({
 	"id": "1",
 	"allowRepeating": true,
 	"source": "console-api",
@@ -140,7 +140,7 @@ stubConsoleMessages.set("console.clear()", new ConsoleMessage({
 	}
 }));
 
-stubConsoleMessages.set("console.count('bar')", new ConsoleMessage({
+stubPreparedMessages.set("console.count('bar')", new ConsoleMessage({
 	"id": "1",
 	"allowRepeating": true,
 	"source": "console-api",
@@ -158,7 +158,7 @@ stubConsoleMessages.set("console.count('bar')", new ConsoleMessage({
 	}
 }));
 
-stubConsoleMessages.set("console.trace()", new ConsoleMessage({
+stubPreparedMessages.set("console.trace()", new ConsoleMessage({
 	"id": "1",
 	"allowRepeating": true,
 	"source": "console-api",
@@ -198,7 +198,7 @@ stubConsoleMessages.set("console.trace()", new ConsoleMessage({
 	}
 }));
 
-stubConsoleMessages.set("console.time('bar')", new ConsoleMessage({
+stubPreparedMessages.set("console.time('bar')", new ConsoleMessage({
 	"id": "1",
 	"allowRepeating": true,
 	"source": "console-api",
@@ -216,7 +216,7 @@ stubConsoleMessages.set("console.time('bar')", new ConsoleMessage({
 	}
 }));
 
-stubConsoleMessages.set("console.timeEnd('bar')", new ConsoleMessage({
+stubPreparedMessages.set("console.timeEnd('bar')", new ConsoleMessage({
 	"id": "1",
 	"allowRepeating": true,
 	"source": "console-api",
@@ -582,6 +582,6 @@ stubPackets.set("console.timeEnd('bar')", {
 
 
 module.exports = {
-  stubConsoleMessages,
+  stubPreparedMessages,
   stubPackets,
 }

--- a/devtools/client/webconsole/new-console-output/test/fixtures/stubs/evaluationResult.js
+++ b/devtools/client/webconsole/new-console-output/test/fixtures/stubs/evaluationResult.js
@@ -9,11 +9,11 @@
 
 const { ConsoleMessage } = require("devtools/client/webconsole/new-console-output/types");
 
-let stubConsoleMessages = new Map();
+let stubPreparedMessages = new Map();
 let stubPackets = new Map();
 
 
-stubConsoleMessages.set("new Date(0)", new ConsoleMessage({
+stubPreparedMessages.set("new Date(0)", new ConsoleMessage({
 	"id": "1",
 	"allowRepeating": true,
 	"source": "javascript",
@@ -61,6 +61,6 @@ stubPackets.set("new Date(0)", {
 
 
 module.exports = {
-  stubConsoleMessages,
+  stubPreparedMessages,
   stubPackets,
 }

--- a/devtools/client/webconsole/new-console-output/test/fixtures/stubs/evaluationResult.js
+++ b/devtools/client/webconsole/new-console-output/test/fixtures/stubs/evaluationResult.js
@@ -10,6 +10,8 @@
 const { ConsoleMessage } = require("devtools/client/webconsole/new-console-output/types");
 
 let stubConsoleMessages = new Map();
+let stubPackets = new Map();
+
 
 stubConsoleMessages.set("new Date(0)", new ConsoleMessage({
 	"id": "1",
@@ -20,7 +22,7 @@ stubConsoleMessages.set("new Date(0)", new ConsoleMessage({
 	"messageText": null,
 	"parameters": {
 		"type": "object",
-		"actor": "server1.conn0.child1/obj29",
+		"actor": "server1.conn0.child1/obj30",
 		"class": "Date",
 		"extensible": true,
 		"frozen": false,
@@ -31,10 +33,34 @@ stubConsoleMessages.set("new Date(0)", new ConsoleMessage({
 		}
 	},
 	"repeat": 1,
-	"repeatId": "{\"id\":null,\"allowRepeating\":true,\"source\":\"javascript\",\"type\":\"result\",\"level\":\"log\",\"messageText\":null,\"parameters\":{\"type\":\"object\",\"actor\":\"server1.conn0.child1/obj29\",\"class\":\"Date\",\"extensible\":true,\"frozen\":false,\"sealed\":false,\"ownPropertyLength\":0,\"preview\":{\"timestamp\":0}},\"repeatId\":null,\"stacktrace\":null,\"frame\":null}",
+	"repeatId": "{\"id\":null,\"allowRepeating\":true,\"source\":\"javascript\",\"type\":\"result\",\"level\":\"log\",\"messageText\":null,\"parameters\":{\"type\":\"object\",\"actor\":\"server1.conn0.child1/obj30\",\"class\":\"Date\",\"extensible\":true,\"frozen\":false,\"sealed\":false,\"ownPropertyLength\":0,\"preview\":{\"timestamp\":0}},\"repeatId\":null,\"stacktrace\":null,\"frame\":null}",
 	"stacktrace": null,
 	"frame": null
 }));
 
 
-module.exports = stubConsoleMessages
+stubPackets.set("new Date(0)", {
+	"from": "server1.conn0.child1/consoleActor2",
+	"input": "new Date(0)",
+	"result": {
+		"type": "object",
+		"actor": "server1.conn0.child1/obj30",
+		"class": "Date",
+		"extensible": true,
+		"frozen": false,
+		"sealed": false,
+		"ownPropertyLength": 0,
+		"preview": {
+			"timestamp": 0
+		}
+	},
+	"timestamp": 1471886229652,
+	"exception": null,
+	"helperResult": null
+});
+
+
+module.exports = {
+  stubConsoleMessages,
+  stubPackets,
+}

--- a/devtools/client/webconsole/new-console-output/test/fixtures/stubs/index.js
+++ b/devtools/client/webconsole/new-console-output/test/fixtures/stubs/index.js
@@ -15,10 +15,10 @@ let maps = [];
 
 // Combine all the maps into a single map.
 module.exports = {
-    stubConsoleMessages: new Map([
-      ...maps.consoleApi.stubConsoleMessages,
-      ...maps.evaluationResult.stubConsoleMessages,
-      ...maps.pageError.stubConsoleMessages, ]),
+    stubPreparedMessages: new Map([
+      ...maps.consoleApi.stubPreparedMessages,
+      ...maps.evaluationResult.stubPreparedMessages,
+      ...maps.pageError.stubPreparedMessages, ]),
     stubPackets: new Map([
       ...maps.consoleApi.stubPackets,
       ...maps.evaluationResult.stubPackets,

--- a/devtools/client/webconsole/new-console-output/test/fixtures/stubs/index.js
+++ b/devtools/client/webconsole/new-console-output/test/fixtures/stubs/index.js
@@ -14,9 +14,13 @@ let maps = [];
 });
 
 // Combine all the maps into a single map.
-module.exports = new Map([
-  ...maps.consoleApi,
-  ...maps.evaluationResult,
-  ...maps.pageError,
-]);
-
+module.exports = {
+    stubConsoleMessages: new Map([
+      ...maps.consoleApi.stubConsoleMessages,
+      ...maps.evaluationResult.stubConsoleMessages,
+      ...maps.pageError.stubConsoleMessages, ]),
+    stubPackets: new Map([
+      ...maps.consoleApi.stubPackets,
+      ...maps.evaluationResult.stubPackets,
+      ...maps.pageError.stubPackets, ]),
+};

--- a/devtools/client/webconsole/new-console-output/test/fixtures/stubs/pageError.js
+++ b/devtools/client/webconsole/new-console-output/test/fixtures/stubs/pageError.js
@@ -10,6 +10,8 @@
 const { ConsoleMessage } = require("devtools/client/webconsole/new-console-output/types");
 
 let stubConsoleMessages = new Map();
+let stubPackets = new Map();
+
 
 stubConsoleMessages.set("ReferenceError: asdf is not defined", new ConsoleMessage({
 	"id": "1",
@@ -26,4 +28,50 @@ stubConsoleMessages.set("ReferenceError: asdf is not defined", new ConsoleMessag
 }));
 
 
-module.exports = stubConsoleMessages
+stubPackets.set("ReferenceError: asdf is not defined", {
+	"from": "server1.conn0.child1/consoleActor2",
+	"type": "pageError",
+	"pageError": {
+		"errorMessage": "ReferenceError: asdf is not defined",
+		"errorMessageName": "JSMSG_NOT_DEFINED",
+		"exceptionDocURL": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Errors/Not_defined?utm_source=mozilla&utm_medium=firefox-console-errors&utm_campaign=default",
+		"sourceName": "data:text/html;charset=utf-8,stub%20generation",
+		"lineText": "",
+		"lineNumber": 1,
+		"columnNumber": 1,
+		"category": "content javascript",
+		"timeStamp": 1471886066466,
+		"warning": false,
+		"error": false,
+		"exception": true,
+		"strict": false,
+		"info": false,
+		"private": false,
+		"stacktrace": [
+			{
+				"filename": "data:text/html;charset=utf-8,stub%20generation",
+				"lineNumber": 1,
+				"columnNumber": 1,
+				"functionName": null
+			},
+			{
+				"filename": "chrome://mochikit/content/tests/BrowserTestUtils/content-task.js line 52 > eval",
+				"lineNumber": 6,
+				"columnNumber": 7,
+				"functionName": null
+			},
+			{
+				"filename": "chrome://mochikit/content/tests/BrowserTestUtils/content-task.js",
+				"lineNumber": 53,
+				"columnNumber": 20,
+				"functionName": null
+			}
+		]
+	}
+});
+
+
+module.exports = {
+  stubConsoleMessages,
+  stubPackets,
+}

--- a/devtools/client/webconsole/new-console-output/test/fixtures/stubs/pageError.js
+++ b/devtools/client/webconsole/new-console-output/test/fixtures/stubs/pageError.js
@@ -9,11 +9,11 @@
 
 const { ConsoleMessage } = require("devtools/client/webconsole/new-console-output/types");
 
-let stubConsoleMessages = new Map();
+let stubPreparedMessages = new Map();
 let stubPackets = new Map();
 
 
-stubConsoleMessages.set("ReferenceError: asdf is not defined", new ConsoleMessage({
+stubPreparedMessages.set("ReferenceError: asdf is not defined", new ConsoleMessage({
 	"id": "1",
 	"allowRepeating": true,
 	"source": "javascript",
@@ -72,6 +72,6 @@ stubPackets.set("ReferenceError: asdf is not defined", {
 
 
 module.exports = {
-  stubConsoleMessages,
+  stubPreparedMessages,
   stubPackets,
 }

--- a/devtools/client/webconsole/new-console-output/test/helpers.js
+++ b/devtools/client/webconsole/new-console-output/test/helpers.js
@@ -10,7 +10,7 @@ var TestUtils = React.addons.TestUtils;
 const actions = require("devtools/client/webconsole/new-console-output/actions/messages");
 const { configureStore } = require("devtools/client/webconsole/new-console-output/store");
 const { IdGenerator } = require("devtools/client/webconsole/new-console-output/utils/id-generator");
-const { stubPreparedMessages } = require("devtools/client/webconsole/new-console-output/test/fixtures/stubs/index");
+const { stubPackets } = require("devtools/client/webconsole/new-console-output/test/fixtures/stubs/index");
 
 /**
  * Prepare actions for use in testing.
@@ -36,7 +36,7 @@ function setupStore(input) {
 
   // Add the messages from the input commands to the store.
   input.forEach((cmd) => {
-    store.dispatch(actions.messageAdd(stubPreparedMessages.get(cmd)));
+    store.dispatch(actions.messageAdd(stubPackets.get(cmd)));
   });
 
   return store;

--- a/devtools/client/webconsole/new-console-output/test/helpers.js
+++ b/devtools/client/webconsole/new-console-output/test/helpers.js
@@ -10,7 +10,7 @@ var TestUtils = React.addons.TestUtils;
 const actions = require("devtools/client/webconsole/new-console-output/actions/messages");
 const { configureStore } = require("devtools/client/webconsole/new-console-output/store");
 const { IdGenerator } = require("devtools/client/webconsole/new-console-output/utils/id-generator");
-const stubConsoleMessages = require("devtools/client/webconsole/new-console-output/test/fixtures/stubs/index");
+const { stubConsoleMessages } = require("devtools/client/webconsole/new-console-output/test/fixtures/stubs/index");
 
 /**
  * Prepare actions for use in testing.

--- a/devtools/client/webconsole/new-console-output/test/helpers.js
+++ b/devtools/client/webconsole/new-console-output/test/helpers.js
@@ -10,7 +10,7 @@ var TestUtils = React.addons.TestUtils;
 const actions = require("devtools/client/webconsole/new-console-output/actions/messages");
 const { configureStore } = require("devtools/client/webconsole/new-console-output/store");
 const { IdGenerator } = require("devtools/client/webconsole/new-console-output/utils/id-generator");
-const { stubConsoleMessages } = require("devtools/client/webconsole/new-console-output/test/fixtures/stubs/index");
+const { stubPreparedMessages } = require("devtools/client/webconsole/new-console-output/test/fixtures/stubs/index");
 
 /**
  * Prepare actions for use in testing.
@@ -36,7 +36,7 @@ function setupStore(input) {
 
   // Add the messages from the input commands to the store.
   input.forEach((cmd) => {
-    store.dispatch(actions.messageAdd(stubConsoleMessages.get(cmd)));
+    store.dispatch(actions.messageAdd(stubPreparedMessages.get(cmd)));
   });
 
   return store;

--- a/devtools/client/webconsole/new-console-output/test/store/messages.test.js
+++ b/devtools/client/webconsole/new-console-output/test/store/messages.test.js
@@ -8,7 +8,7 @@ const {
   setupActions,
   setupStore
 } = require("devtools/client/webconsole/new-console-output/test/helpers");
-const { stubConsoleMessages } = require("devtools/client/webconsole/new-console-output/test/fixtures/stubs/index");
+const { stubPreparedMessages } = require("devtools/client/webconsole/new-console-output/test/fixtures/stubs/index");
 
 const expect = require("expect");
 
@@ -22,7 +22,7 @@ describe("Message reducer:", () => {
   it("adds a message to an empty store", () => {
     const { dispatch, getState } = setupStore([]);
 
-    const message = stubConsoleMessages.get("console.log('foobar', 'test')");
+    const message = stubPreparedMessages.get("console.log('foobar', 'test')");
     dispatch(actions.messageAdd(message));
 
     const messages = getAllMessages(getState());
@@ -38,7 +38,7 @@ describe("Message reducer:", () => {
       "console.log('foobar', 'test')"
     ]);
 
-    const message = stubConsoleMessages.get("console.log('foobar', 'test')");
+    const message = stubPreparedMessages.get("console.log('foobar', 'test')");
     dispatch(actions.messageAdd(message));
     dispatch(actions.messageAdd(message));
 
@@ -54,10 +54,10 @@ describe("Message reducer:", () => {
       "console.log('foobar', 'test')"
     ]);
 
-    const message = stubConsoleMessages.get("console.log('foobar', 'test')");
+    const message = stubPreparedMessages.get("console.log('foobar', 'test')");
     dispatch(actions.messageAdd(message));
 
-    const message2 = stubConsoleMessages.get("console.log(undefined)");
+    const message2 = stubPreparedMessages.get("console.log(undefined)");
     dispatch(actions.messageAdd(message2));
 
     const messages = getAllMessages(getState());
@@ -73,7 +73,7 @@ describe("Message reducer:", () => {
       "console.log(undefined)"
     ]);
 
-    dispatch(actions.messageAdd(stubConsoleMessages.get("console.clear()")));
+    dispatch(actions.messageAdd(stubPreparedMessages.get("console.clear()")));
 
     const messages = getAllMessages(getState());
 
@@ -85,7 +85,7 @@ describe("Message reducer:", () => {
     const { dispatch, getState } = setupStore([]);
 
     const logLimit = 1000;
-    const baseMessage = stubConsoleMessages.get("console.log(undefined)");
+    const baseMessage = stubPreparedMessages.get("console.log(undefined)");
     for (let i = 1; i <= logLimit + 1; i++) {
       const msg = baseMessage.set("parameters", [`message num ${i}`]);
       dispatch(actions.messageAdd(msg));
@@ -100,7 +100,7 @@ describe("Message reducer:", () => {
   it("does not add null messages to the store", () => {
     const { dispatch, getState } = setupStore([]);
 
-    const message = stubConsoleMessages.get("console.time('bar')");
+    const message = stubPreparedMessages.get("console.time('bar')");
     dispatch(actions.messageAdd(message));
 
     const messages = getAllMessages(getState());

--- a/devtools/client/webconsole/new-console-output/test/store/messages.test.js
+++ b/devtools/client/webconsole/new-console-output/test/store/messages.test.js
@@ -8,7 +8,7 @@ const {
   setupActions,
   setupStore
 } = require("devtools/client/webconsole/new-console-output/test/helpers");
-const { stubPreparedMessages } = require("devtools/client/webconsole/new-console-output/test/fixtures/stubs/index");
+const { stubPackets, stubPreparedMessages } = require("devtools/client/webconsole/new-console-output/test/fixtures/stubs/index");
 
 const expect = require("expect");
 
@@ -22,14 +22,13 @@ describe("Message reducer:", () => {
   it("adds a message to an empty store", () => {
     const { dispatch, getState } = setupStore([]);
 
+    const packet = stubPackets.get("console.log('foobar', 'test')");
     const message = stubPreparedMessages.get("console.log('foobar', 'test')");
-    dispatch(actions.messageAdd(message));
+    dispatch(actions.messageAdd(packet));
 
     const messages = getAllMessages(getState());
 
-    // @TODO Remove repeatId once stubs are generated using prepareMessage.
-    let expected = message.set("repeatId", getRepeatId(message)).set("id", "1");
-    expect(messages.first()).toEqual(expected);
+    expect(messages.first()).toEqual(message);
   });
 
   it("increments repeat on a repeating message", () => {
@@ -38,9 +37,9 @@ describe("Message reducer:", () => {
       "console.log('foobar', 'test')"
     ]);
 
-    const message = stubPreparedMessages.get("console.log('foobar', 'test')");
-    dispatch(actions.messageAdd(message));
-    dispatch(actions.messageAdd(message));
+    const packet = stubPackets.get("console.log('foobar', 'test')");
+    dispatch(actions.messageAdd(packet));
+    dispatch(actions.messageAdd(packet));
 
     const messages = getAllMessages(getState());
 
@@ -54,11 +53,11 @@ describe("Message reducer:", () => {
       "console.log('foobar', 'test')"
     ]);
 
-    const message = stubPreparedMessages.get("console.log('foobar', 'test')");
-    dispatch(actions.messageAdd(message));
+    const packet = stubPackets.get("console.log('foobar', 'test')");
+    dispatch(actions.messageAdd(packet));
 
-    const message2 = stubPreparedMessages.get("console.log(undefined)");
-    dispatch(actions.messageAdd(message2));
+    const packet2 = stubPackets.get("console.log(undefined)");
+    dispatch(actions.messageAdd(packet2));
 
     const messages = getAllMessages(getState());
 
@@ -73,7 +72,7 @@ describe("Message reducer:", () => {
       "console.log(undefined)"
     ]);
 
-    dispatch(actions.messageAdd(stubPreparedMessages.get("console.clear()")));
+    dispatch(actions.messageAdd(stubPackets.get("console.clear()")));
 
     const messages = getAllMessages(getState());
 
@@ -85,10 +84,10 @@ describe("Message reducer:", () => {
     const { dispatch, getState } = setupStore([]);
 
     const logLimit = 1000;
-    const baseMessage = stubPreparedMessages.get("console.log(undefined)");
+    const packet = stubPackets.get("console.log(undefined)");
     for (let i = 1; i <= logLimit + 1; i++) {
-      const msg = baseMessage.set("parameters", [`message num ${i}`]);
-      dispatch(actions.messageAdd(msg));
+      packet.message.arguments = [`message num ${i}`];
+      dispatch(actions.messageAdd(packet));
     }
 
     const messages = getAllMessages(getState());
@@ -100,7 +99,7 @@ describe("Message reducer:", () => {
   it("does not add null messages to the store", () => {
     const { dispatch, getState } = setupStore([]);
 
-    const message = stubPreparedMessages.get("console.time('bar')");
+    const message = stubPackets.get("console.time('bar')");
     dispatch(actions.messageAdd(message));
 
     const messages = getAllMessages(getState());

--- a/devtools/client/webconsole/new-console-output/test/store/messages.test.js
+++ b/devtools/client/webconsole/new-console-output/test/store/messages.test.js
@@ -8,7 +8,7 @@ const {
   setupActions,
   setupStore
 } = require("devtools/client/webconsole/new-console-output/test/helpers");
-const stubConsoleMessages = require("devtools/client/webconsole/new-console-output/test/fixtures/stubs/index");
+const { stubConsoleMessages } = require("devtools/client/webconsole/new-console-output/test/fixtures/stubs/index");
 
 const expect = require("expect");
 

--- a/devtools/client/webconsole/new-console-output/test/utils/getRepeatId.test.js
+++ b/devtools/client/webconsole/new-console-output/test/utils/getRepeatId.test.js
@@ -3,7 +3,7 @@
 "use strict";
 
 const { getRepeatId } = require("devtools/client/webconsole/new-console-output/utils/messages");
-const stubConsoleMessages = require("devtools/client/webconsole/new-console-output/test/fixtures/stubs/index");
+const { stubConsoleMessages } = require("devtools/client/webconsole/new-console-output/test/fixtures/stubs/index");
 
 const expect = require("expect");
 

--- a/devtools/client/webconsole/new-console-output/test/utils/getRepeatId.test.js
+++ b/devtools/client/webconsole/new-console-output/test/utils/getRepeatId.test.js
@@ -3,33 +3,33 @@
 "use strict";
 
 const { getRepeatId } = require("devtools/client/webconsole/new-console-output/utils/messages");
-const { stubConsoleMessages } = require("devtools/client/webconsole/new-console-output/test/fixtures/stubs/index");
+const { stubPreparedMessages } = require("devtools/client/webconsole/new-console-output/test/fixtures/stubs/index");
 
 const expect = require("expect");
 
 describe("getRepeatId:", () => {
   it("returns same repeatId for duplicate values", () => {
-    const message1 = stubConsoleMessages.get("console.log('foobar', 'test')");
+    const message1 = stubPreparedMessages.get("console.log('foobar', 'test')");
     const message2 = message1.set("repeat", 3);
     expect(getRepeatId(message1)).toEqual(getRepeatId(message2));
   });
 
   it("returns different repeatIds for different values", () => {
-    const message1 = stubConsoleMessages.get("console.log('foobar', 'test')");
+    const message1 = stubPreparedMessages.get("console.log('foobar', 'test')");
     const message2 = message1.set("parameters", ["funny", "monkey"]);
     expect(getRepeatId(message1)).toNotEqual(getRepeatId(message2));
   });
 
   it("returns different repeatIds for different severities", () => {
-    const message1 = stubConsoleMessages.get("console.log('foobar', 'test')");
+    const message1 = stubPreparedMessages.get("console.log('foobar', 'test')");
     const message2 = message1.set("level", "error");
     expect(getRepeatId(message1)).toNotEqual(getRepeatId(message2));
   });
 
   it("handles falsy values distinctly", () => {
-    const messageNaN = stubConsoleMessages.get("console.log(NaN)");
-    const messageUnd = stubConsoleMessages.get("console.log(undefined)");
-    const messageNul = stubConsoleMessages.get("console.log(null)");
+    const messageNaN = stubPreparedMessages.get("console.log(NaN)");
+    const messageUnd = stubPreparedMessages.get("console.log(undefined)");
+    const messageNul = stubPreparedMessages.get("console.log(null)");
 
     const repeatIds = new Set([
       getRepeatId(messageNaN),


### PR DESCRIPTION
Fixes #218 

This PR adds `stubPackets` and then feeds those into `dispatch` in the store tests.

@bgrins This is ready for review. You might want to do commit-by-commit review instead of the whole thing... this PR looks more complicated than it is.
