### PR TITLE
Support network event messages by reusing current ConsoleMessage

### DIFF
--- a/devtools/client/webconsole/new-console-output/utils/messages.js
+++ b/devtools/client/webconsole/new-console-output/utils/messages.js
@@ -131,6 +131,18 @@ function transformPacket(packet) {
       });
     }
 
+    case "networkEvent": {
+      let { networkEvent } = packet;
+
+      // TODO: Replace the ConsoleMessage with NetworkEventMessage
+      //       once the new component is ready.
+      return new ConsoleMessage({
+        source: MESSAGE_SOURCE.CONSOLE_API,
+        type: MESSAGE_TYPE.LOG,
+        level: MESSAGE_LEVEL.LOG,
+        messageText: networkEvent.request.method + " " + networkEvent.request.url,
+      });
+    }
     case "evaluationResult":
     default: {
       let { result } = packet;
@@ -165,6 +177,9 @@ function convertCachedPacket(packet) {
   } else if ("_navPayload" in packet) {
     convertPacket.type = "navigationMessage";
     convertPacket.message = packet;
+  } else if (packet._type === "NetworkEvent") {
+    convertPacket.networkEvent = packet;
+    convertPacket.type = "networkEvent";
   } else {
     throw new Error("Unexpected packet type");
   }

--- a/devtools/client/webconsole/webconsole.js
+++ b/devtools/client/webconsole/webconsole.js
@@ -3351,6 +3351,10 @@ WebConsoleConnectionProxy.prototype = {
    */
   _onNetworkEvent: function (type, networkInfo) {
     if (this.webConsoleFrame) {
+      if (this.webConsoleFrame.NEW_CONSOLE_OUTPUT_ENABLED) {
+        this.dispatchMessageAdd(networkInfo);
+        return;
+      }
       this.webConsoleFrame.handleNetworkEvent(networkInfo);
     }
   },


### PR DESCRIPTION
This patch simply applied ConsoleMessage for showing the network event message with method and url only. It will need more follow up like new component for network event.
