### PR TITLE
Add a default value for the open prop in ConsoleApiCall and MessageContainer

### DIFF
--- a/devtools/client/webconsole/new-console-output/components/message-container.js
+++ b/devtools/client/webconsole/new-console-output/components/message-container.js
@@ -36,6 +36,12 @@ const MessageContainer = createClass({
     open: PropTypes.bool.isRequired,
   },
 
+  getDefaultProps: function () {
+    return {
+      open: false
+    };
+  },
+
   shouldComponentUpdate(nextProps, nextState) {
     return this.props.message.repeat !== nextProps.message.repeat
       || this.props.open !== nextProps.open;

--- a/devtools/client/webconsole/new-console-output/components/message-types/console-api-call.js
+++ b/devtools/client/webconsole/new-console-output/components/message-types/console-api-call.js
@@ -30,6 +30,10 @@ ConsoleApiCall.propTypes = {
   open: PropTypes.bool.isRequired,
 };
 
+ConsoleApiCall.defaultProps = {
+  open: false
+};
+
 function ConsoleApiCall(props) {
   const { dispatch, message, sourceMapService, onViewSourceInDebugger, open } = props;
   const { source, level, stacktrace, type, frame, parameters } = message;


### PR DESCRIPTION
Fixes #258
Removes warning in tests
## Testing instructions
1. `npm test`
2. Make sure there isn't warnings about the open property anymore
