### PR TITLE
Update text filtering and expand tests

### DIFF
--- a/devtools/client/webconsole/new-console-output/selectors/messages.js
+++ b/devtools/client/webconsole/new-console-output/selectors/messages.js
@@ -42,7 +42,7 @@ function search(messages, text = "") {
   }
 
   return messages.filter(function (message) {
-    // Evaluation Results are never filtered.
+    // Evaluation Results and Console Commands are never filtered.
     if ([ MESSAGE_TYPE.RESULT, MESSAGE_TYPE.COMMAND ].includes(message.type)) {
       return true;
     }
@@ -54,8 +54,7 @@ function search(messages, text = "") {
       // Look for a match in location.
       // @TODO Change this to Object.values once it's supported in Node's version of V8
       || Object.keys(message.frame)
-        .map(key => message
-        .frame[key])
+        .map(key => message.frame[key])
         .join(":")
         .includes(text)
       // Look for a match in messageText.

--- a/devtools/client/webconsole/new-console-output/selectors/messages.js
+++ b/devtools/client/webconsole/new-console-output/selectors/messages.js
@@ -42,14 +42,30 @@ function search(messages, text = "") {
   }
 
   return messages.filter(function (message) {
-    // @TODO: message.parameters can be a grip, see how we can handle that
-    if (!Array.isArray(message.parameters)) {
+    // Evaluation Results are never filtered.
+    if ([ MESSAGE_TYPE.RESULT, MESSAGE_TYPE.COMMAND ].includes(message.type)) {
       return true;
     }
-    return message
-      .parameters.join("")
-      .toLocaleLowerCase()
-      .includes(text.toLocaleLowerCase());
+
+    return (
+      // @TODO currently we return true for any object grip. We should find a way to
+      // search object grips.
+      message.parameters !== null && !Array.isArray(message.parameters)
+      // Look for a match in location.
+      // @TODO Change this to Object.values once it's supported in Node's version of V8
+      || Object.keys(message.frame)
+        .map(key => message
+        .frame[key])
+        .join(":")
+        .includes(text)
+      // Look for a match in messageText.
+      || (message.messageText !== null
+            && message.messageText.toLocaleLowerCase().includes(text.toLocaleLowerCase()))
+      // Look for a match in parameters. Currently only checks value grips.
+      || (message.parameters !== null
+          && message.parameters.join("").toLocaleLowerCase()
+              .includes(text.toLocaleLowerCase()))
+    );
   });
 }
 

--- a/devtools/client/webconsole/new-console-output/test/fixtures/stub-generators/stub-snippets.js
+++ b/devtools/client/webconsole/new-console-output/test/fixtures/stub-generators/stub-snippets.js
@@ -11,6 +11,7 @@ const consoleApiCommands = [
   "console.warn('danger, will robinson!')",
   "console.log(NaN)",
   "console.log(null)",
+  "console.log('\u9f2c')",
   "console.clear()",
   "console.count('bar')",
   "console.assert(false, {message: 'foobar'})"

--- a/devtools/client/webconsole/new-console-output/test/fixtures/stubs/consoleApi.js
+++ b/devtools/client/webconsole/new-console-output/test/fixtures/stubs/consoleApi.js
@@ -120,6 +120,26 @@ stubPreparedMessages.set("console.log(null)", new ConsoleMessage({
 	}
 }));
 
+stubPreparedMessages.set("console.log('鼬')", new ConsoleMessage({
+	"id": "1",
+	"allowRepeating": true,
+	"source": "console-api",
+	"type": "log",
+	"level": "log",
+	"messageText": null,
+	"parameters": [
+		"鼬"
+	],
+	"repeat": 1,
+	"repeatId": "{\"id\":null,\"allowRepeating\":true,\"source\":\"console-api\",\"type\":\"log\",\"level\":\"log\",\"messageText\":null,\"parameters\":[\"鼬\"],\"repeatId\":null,\"stacktrace\":null,\"frame\":{\"source\":\"http://example.com/browser/devtools/client/webconsole/new-console-output/test/fixtures/stub-generators/test-tempfile.js\",\"line\":1,\"column\":27}}",
+	"stacktrace": null,
+	"frame": {
+		"source": "http://example.com/browser/devtools/client/webconsole/new-console-output/test/fixtures/stub-generators/test-tempfile.js",
+		"line": 1,
+		"column": 27
+	}
+}));
+
 stubPreparedMessages.set("console.clear()", new ConsoleMessage({
 	"id": "1",
 	"allowRepeating": true,
@@ -446,8 +466,39 @@ stubPackets.set("console.log(null)", {
 	}
 });
 
-stubPackets.set("console.clear()", {
+stubPackets.set("console.log('鼬')", {
 	"from": "server1.conn5.child1/consoleActor2",
+	"type": "consoleAPICall",
+	"message": {
+		"arguments": [
+			"鼬"
+		],
+		"columnNumber": 27,
+		"counter": null,
+		"filename": "http://example.com/browser/devtools/client/webconsole/new-console-output/test/fixtures/stub-generators/test-tempfile.js",
+		"functionName": "triggerPacket",
+		"groupName": "",
+		"level": "log",
+		"lineNumber": 1,
+		"originAttributes": {
+			"addonId": "",
+			"appId": 0,
+			"inIsolatedMozBrowser": false,
+			"privateBrowsingId": 0,
+			"signedPkg": "",
+			"userContextId": 0
+		},
+		"private": false,
+		"styles": [],
+		"timeStamp": 1473786764817,
+		"timer": null,
+		"workerType": "none",
+		"category": "webdev"
+	}
+});
+
+stubPackets.set("console.clear()", {
+	"from": "server1.conn6.child1/consoleActor2",
 	"type": "consoleAPICall",
 	"message": {
 		"arguments": [],

--- a/devtools/client/webconsole/new-console-output/test/store/filters.test.js
+++ b/devtools/client/webconsole/new-console-output/test/store/filters.test.js
@@ -66,6 +66,15 @@ describe("Filtering", () => {
       expect(messages.size).toEqual(3);
     });
 
+    it("matches unicode values", () => {
+      store.dispatch(messageAdd(stubPackets.get("console.log('鼬')")));
+      store.dispatch(actions.filterTextSet("鼬"));
+
+      let messages = getAllMessages(store.getState());
+      // This does not filter out Evaluation Results or console commands
+      expect(messages.size).toEqual(3);
+    });
+
     it("matches locations", () => {
       // Add a message with a different filename.
       let locationMsg =

--- a/devtools/client/webconsole/new-console-output/test/store/filters.test.js
+++ b/devtools/client/webconsole/new-console-output/test/store/filters.test.js
@@ -29,7 +29,7 @@ describe("Filtering", () => {
       store.dispatch(actions.filterToggle(MESSAGE_LEVEL.LOG));
 
       let messages = getAllMessages(store.getState());
-      expect(messages.size).toEqual(numMessages - 2);
+      expect(messages.size).toEqual(numMessages - 3);
     });
 
     it("filters debug messages", () => {
@@ -67,7 +67,6 @@ describe("Filtering", () => {
     });
 
     it("matches unicode values", () => {
-      store.dispatch(messageAdd(stubPackets.get("console.log('鼬')")));
       store.dispatch(actions.filterTextSet("鼬"));
 
       let messages = getAllMessages(store.getState());
@@ -143,6 +142,7 @@ function prepareBaseStore() {
     "console.warn('danger, will robinson!')",
     "console.log(undefined)",
     "console.count('bar')",
+    "console.log('鼬')",
     // Evaluation Result - never filtered
     "new Date(0)",
     // PageError

--- a/devtools/client/webconsole/new-console-output/test/store/filters.test.js
+++ b/devtools/client/webconsole/new-console-output/test/store/filters.test.js
@@ -12,25 +12,16 @@ const { getAllMessages } = require("devtools/client/webconsole/new-console-outpu
 const { getAllFilters } = require("devtools/client/webconsole/new-console-output/selectors/filters");
 const { setupStore } = require("devtools/client/webconsole/new-console-output/test/helpers");
 const { MESSAGE_LEVEL } = require("devtools/client/webconsole/new-console-output/constants");
+const { stubPackets } = require("devtools/client/webconsole/new-console-output/test/fixtures/stubs/index");
 
 describe("Filtering", () => {
-  const numMessages = 7;
-  const store = setupStore([
-    // Console API
-    "console.log('foobar', 'test')",
-    "console.warn('danger, will robinson!')",
-    "console.log(undefined)",
-    "console.count('bar')",
-    // Evaluation Result
-    "new Date(0)",
-    // PageError
-    "ReferenceError: asdf is not defined"
-  ]);
-  // Console Command
-  store.dispatch(messageAdd(new ConsoleCommand({ messageText: `console.warn("x")` })));
+  let store;
+  let numMessages;
 
   beforeEach(() => {
+    store = prepareBaseStore();
     store.dispatch(actions.filtersClear());
+    numMessages = getAllMessages(store.getState()).size;
   });
 
   describe("Level filter", () => {
@@ -71,9 +62,31 @@ describe("Filtering", () => {
       store.dispatch(actions.filterTextSet("danger"));
 
       let messages = getAllMessages(store.getState());
-      // @TODO figure out what this should filter
-      // This does not filter out PageErrors, Evaluation Results or console commands
-      expect(messages.size).toEqual(5);
+      // This does not filter out Evaluation Results or console commands
+      expect(messages.size).toEqual(3);
+    });
+
+    it("matches locations", () => {
+      // Add a message with a different filename.
+      let locationMsg =
+        Object.assign({}, stubPackets.get("console.log('foobar', 'test')"));
+      locationMsg.message =
+        Object.assign({}, locationMsg.message, { filename: "search-location-test.js" });
+      store.dispatch(messageAdd(locationMsg));
+
+      store.dispatch(actions.filterTextSet("search-location-test.js"));
+
+      let messages = getAllMessages(store.getState());
+      // This does not filter out Evaluation Results or console commands
+      expect(messages.size).toEqual(3);
+    });
+
+    it("restores all messages once text is cleared", () => {
+      store.dispatch(actions.filterTextSet("danger"));
+      store.dispatch(actions.filterTextSet(""));
+
+      let messages = getAllMessages(store.getState());
+      expect(messages.size).toEqual(numMessages);
     });
   });
 
@@ -113,3 +126,22 @@ describe("Clear filters", () => {
     });
   });
 });
+
+function prepareBaseStore() {
+  const store = setupStore([
+    // Console API
+    "console.log('foobar', 'test')",
+    "console.warn('danger, will robinson!')",
+    "console.log(undefined)",
+    "console.count('bar')",
+    // Evaluation Result - never filtered
+    "new Date(0)",
+    // PageError
+    "ReferenceError: asdf is not defined"
+  ]);
+
+  // Console Command - never filtered
+  store.dispatch(messageAdd(new ConsoleCommand({ messageText: `console.warn("x")` })));
+
+  return store;
+}


### PR DESCRIPTION
Fixes #220

This changes our text filtering a bit. We still don't properly support object grips, and we also don't support searching stacktraces. I'm going to create an issue for that.

@bgrins you can find the tests that it is supposed to replace in the original issue
