### PR TITLE
Bug 1302873 - New console frontend: Remove quotes around strings. r=b…

### DIFF
--- a/devtools/client/shared/components/reps/string.js
+++ b/devtools/client/shared/components/reps/string.js
@@ -21,6 +21,16 @@ define(function (require, exports, module) {
   const StringRep = React.createClass({
     displayName: "StringRep",
 
+    propTypes: {
+      useQuotes: React.PropTypes.bool,
+    },
+
+    getDefaultProps: function () {
+      return {
+        useQuotes: true,
+      };
+    },
+
     render: function () {
       let text = this.props.object;
       let member = this.props.member;
@@ -35,8 +45,8 @@ define(function (require, exports, module) {
       let croppedString = this.props.cropLimit ?
         cropMultipleLines(text, this.props.cropLimit) : cropMultipleLines(text);
 
-      let formattedString = this.props.omitQuotes ?
-        croppedString : "\"" + croppedString + "\"";
+      let formattedString = this.props.useQuotes ?
+        "\"" + croppedString + "\"" : croppedString;
 
       return (
         span({className: "objectBox objectBox-string"}, formattedString

--- a/devtools/client/shared/components/test/mochitest/test_reps_string.html
+++ b/devtools/client/shared/components/test/mochitest/test_reps_string.html
@@ -27,7 +27,7 @@ window.onload = Task.async(function* () {
     yield testMultiline();
     yield testMultilineOpen();
     yield testMultilineLimit();
-    yield testOmitQuotes();
+    yield testUseQuotes();
   } catch(e) {
     ok(false, "Got an error: " + DevToolsUtils.safeErrorString(e));
   } finally {
@@ -49,9 +49,9 @@ window.onload = Task.async(function* () {
     is(renderedComponent.textContent, "\"aaaaaaaaaaaaaaaaaaaaa\nbbbbbbbbbbbbbbbbbbb\ncccccccccccccccc\n\"", "String rep has expected text content for multiline string when open");
   }
 
-  function testOmitQuotes(){
-     const renderedComponent = renderComponent(StringRep.rep, { object: getGripStub("testOmitQuotes"), omitQuotes: true });
-     is(renderedComponent.textContent, "abc","String rep has expected to omit quotes");
+  function testUseQuotes(){
+     const renderedComponent = renderComponent(StringRep.rep, { object: getGripStub("testUseQuotes"), useQuotes: false });
+     is(renderedComponent.textContent, "abc","String rep was expected to omit quotes");
   }
 
   function getGripStub(name) {
@@ -59,7 +59,7 @@ window.onload = Task.async(function* () {
       case "testMultiline":
       	 return "aaaaaaaaaaaaaaaaaaaaa\nbbbbbbbbbbbbbbbbbbb\ncccccccccccccccc\n";
 	 break;
-      case "testOmitQuotes":
+      case "testUseQuotes":
 	 return "abc";
     }
   }

--- a/devtools/client/webconsole/new-console-output/components/grip-message-body.js
+++ b/devtools/client/webconsole/new-console-output/components/grip-message-body.js
@@ -19,6 +19,7 @@ const {
 } = require("devtools/client/shared/vendor/react");
 const { createFactories } = require("devtools/client/shared/components/reps/rep-utils");
 const { Rep } = createFactories(require("devtools/client/shared/components/reps/rep"));
+const StringRep = createFactories(require("devtools/client/shared/components/reps/string").StringRep).rep;
 const VariablesViewLink = createFactory(require("devtools/client/webconsole/new-console-output/components/variables-view-link").VariablesViewLink);
 const { Grip } = require("devtools/client/shared/components/reps/grip");
 
@@ -33,11 +34,20 @@ GripMessageBody.propTypes = {
 };
 
 function GripMessageBody(props) {
-  return Rep({
-    object: props.grip,
-    objectLink: VariablesViewLink,
-    defaultRep: Grip
-  });
+  const { grip } = props;
+
+  return (
+    typeof grip === "string"
+      ? StringRep({
+        object: grip,
+        useQuotes: false
+      })
+      : Rep({
+        object: grip,
+        objectLink: VariablesViewLink,
+        defaultRep: Grip
+      })
+  );
 }
 
 module.exports.GripMessageBody = GripMessageBody;

--- a/devtools/client/webconsole/new-console-output/components/grip-message-body.js
+++ b/devtools/client/webconsole/new-console-output/components/grip-message-body.js
@@ -37,6 +37,7 @@ function GripMessageBody(props) {
   const { grip } = props;
 
   return (
+    // @TODO once there is a longString rep, also turn off quotes for those.
     typeof grip === "string"
       ? StringRep({
         object: grip,

--- a/devtools/client/webconsole/new-console-output/components/message-types/console-api-call.js
+++ b/devtools/client/webconsole/new-console-output/components/message-types/console-api-call.js
@@ -41,10 +41,10 @@ function ConsoleApiCall(props) {
   if (type === "trace") {
     messageBody = dom.span({ className: "cm-variable" }, "console.trace()");
   } else if (type === "assert") {
-    let reps = parameters.map((grip, key) => GripMessageBody({ grip, key }));
+    let reps = formatReps(parameters);
     messageBody = dom.span({ className: "cm-variable" }, "Assertion failed: ", reps);
   } else if (parameters) {
-    messageBody = parameters.map((grip, key) => GripMessageBody({ grip, key }));
+    messageBody = formatReps(parameters);
   } else {
     messageBody = message.messageText;
   }
@@ -114,6 +114,20 @@ function ConsoleApiCall(props) {
       ),
       attachment
     )
+  );
+}
+
+function formatReps(parameters) {
+  return (
+    parameters
+      // Get all the grips.
+      .map((grip, key) => GripMessageBody({ grip, key }))
+      // Interleave spaces.
+      .reduce((arr, v, i) => {
+        return i + 1 < parameters.length
+          ? arr.concat(v, dom.span({}, " "))
+          : arr.concat(v);
+      }, [])
   );
 }
 

--- a/devtools/client/webconsole/new-console-output/test/components/console-api-call.test.js
+++ b/devtools/client/webconsole/new-console-output/test/components/console-api-call.test.js
@@ -24,8 +24,7 @@ describe("ConsoleAPICall component:", () => {
       const message = stubPreparedMessages.get("console.log('foobar', 'test')");
       const wrapper = render(ConsoleApiCall({ message, onViewSourceInDebugger }));
 
-      // @TODO should output: foobar test
-      expect(wrapper.find(".message-body").text()).toBe("\"foobar\"\"test\"");
+      expect(wrapper.find(".message-body").text()).toBe("foobar test");
       expect(wrapper.find(".objectBox-string").length).toBe(2);
       expect(wrapper.find("div.message.cm-s-mozilla span span.message-flex-body span.message-body.devtools-monospace").length).toBe(1);
     });


### PR DESCRIPTION
Fixes #275 
## Testing instructions
1. `console.log("foo", "bar")`
2. `console.log({}, {})`

@bgrins this is ready for review
