### PR TITLE
Add location to pageError messages

### DIFF
--- a/devtools/client/webconsole/new-console-output/components/message-types/page-error.js
+++ b/devtools/client/webconsole/new-console-output/components/message-types/page-error.js
@@ -47,7 +47,6 @@ function PageError(props) {
     }) : null
   );
 
-
   let collapse = "";
   let attachment = "";
   if (stacktrace) {
@@ -96,7 +95,8 @@ function PageError(props) {
         dom.span({ className: "message-body devtools-monospace" },
           message.messageText
         ),
-        repeat
+        repeat,
+        location
       ),
       attachment
     )

--- a/devtools/client/webconsole/new-console-output/test/components/page-error.test.js
+++ b/devtools/client/webconsole/new-console-output/test/components/page-error.test.js
@@ -23,6 +23,11 @@ describe("PageError component:", () => {
     // The stacktrace should be closed by default.
     const frameLinks = wrapper.find(`.stack-trace`);
     expect(frameLinks.length).toBe(0);
+
+    // There should be the location
+    const locationLink = wrapper.find(`.message-location`);
+    expect(locationLink.length).toBe(1);
+    expect(locationLink.text()).toBe("test-tempfile.js:3:5");
   });
 
   it("has a stacktrace which can be openned", () => {


### PR DESCRIPTION
Fixes #263
Regression from #107. We add a test to make sure the location is displayed.
## Testing instructions
1. run `npm test` in `devtools/client/webconsole/`
