### PR TITLE
Bug 1303812 - New console frontend: Hide CSS page errors. r=bgrins

### DIFF
--- a/devtools/client/webconsole/webconsole.js
+++ b/devtools/client/webconsole/webconsole.js
@@ -3324,7 +3324,10 @@ WebConsoleConnectionProxy.prototype = {
   _onPageError: function (type, packet) {
     if (this.webConsoleFrame && packet.from == this._consoleActor) {
       if (this.webConsoleFrame.NEW_CONSOLE_OUTPUT_ENABLED) {
-        this.dispatchMessageAdd(packet);
+        let category = Utils.categoryForScriptError(packet.pageError);
+        if (category !== CATEGORY_CSS) {
+          this.dispatchMessageAdd(packet);
+        }
         return;
       }
       this.webConsoleFrame.handlePageError(packet.pageError);


### PR DESCRIPTION
Fixes #287

@bgrins this is ready for review
## Testing instructions
1. Open console
2. Go to Twitter.com
3. Before you would have seen many CSS Errors. Now you only see the other page errors.
