### PR TITLE
Bug 1303989 - New console frontend: Focus outline flicker on #output-…

### DIFF
--- a/devtools/client/webconsole/new-console-output/utils/variables-view.js
+++ b/devtools/client/webconsole/new-console-output/utils/variables-view.js
@@ -12,6 +12,9 @@
  *
  * Once JSTerm is also written in React/Redux, these will be actions.
  */
-exports.openVariablesView = (object) => {
-  window.jsterm.openVariablesView({objectActor: object});
+exports.openVariablesView = (objectActor) => {
+  window.jsterm.openVariablesView({
+    objectActor,
+    autofocus: true,
+  });
 };


### PR DESCRIPTION
Fixes #246 

This is just copying over functionality that was already in the existing console. @bgrins, this is required for #293 to work
## Testing instructions
1. `console.log({})`
2. Click on `Object`

Before, the output would stay focused. Now the variables view gets focus
