### PR TITLE
Remove outline for focused div;r=linclark

### DIFF
--- a/devtools/client/webconsole/webconsole.js
+++ b/devtools/client/webconsole/webconsole.js
@@ -582,6 +582,7 @@ WebConsoleFrame.prototype = {
       // XXX: We should actually stop output from happening on old output
       // panel, but for now let's just hide it.
       this.experimentalOutputNode = this.outputNode.cloneNode();
+      this.experimentalOutputNode.removeAttribute("tabindex");
       this.outputNode.hidden = true;
       this.outputNode.parentNode.appendChild(this.experimentalOutputNode);
       // @TODO Once the toolbox has been converted to React, see if passing


### PR DESCRIPTION
Fixes #296
## Testing instructions
1. Open console
2. Click in output area
3. See if there's an outline that shows up around a container element (there shouldn't be)
