### PR TITLE
Add network messages filtering in the filter bar. r=linclark

### DIFF
--- a/devtools/client/webconsole/new-console-output/components/filter-bar.js
+++ b/devtools/client/webconsole/new-console-output/components/filter-bar.js
@@ -103,6 +103,21 @@ const FilterBar = createClass({
             label: "Debug",
             filterKey: MESSAGE_LEVEL.DEBUG,
             dispatch
+          }),
+          dom.span({
+            className: "devtools-separator",
+          }),
+          FilterButton({
+            active: filter.netxhr,
+            label: "XHR",
+            filterKey: "netxhr",
+            dispatch
+          }),
+          FilterButton({
+            active: filter.network,
+            label: "Requests",
+            filterKey: "network",
+            dispatch
           })
         )
       );

--- a/devtools/client/webconsole/new-console-output/reducers/filters.js
+++ b/devtools/client/webconsole/new-console-output/reducers/filters.js
@@ -13,6 +13,8 @@ const FilterState = Immutable.Record({
   error: true,
   info: true,
   log: true,
+  network: true,
+  netxhr: true,
   text: "",
   warn: true,
 });

--- a/devtools/client/webconsole/new-console-output/selectors/messages.js
+++ b/devtools/client/webconsole/new-console-output/selectors/messages.js
@@ -9,7 +9,8 @@ const { l10n } = require("devtools/client/webconsole/new-console-output/utils/me
 const { getAllFilters } = require("devtools/client/webconsole/new-console-output/selectors/filters");
 const { getLogLimit } = require("devtools/client/webconsole/new-console-output/selectors/prefs");
 const {
-  MESSAGE_TYPE
+  MESSAGE_TYPE,
+  MESSAGE_SOURCE
 } = require("devtools/client/webconsole/new-console-output/constants");
 
 function getAllMessages(state) {
@@ -19,7 +20,10 @@ function getAllMessages(state) {
 
   return prune(
     search(
-      filterLevel(messages, filters),
+      filterNetwork(
+        filterLevel(messages, filters),
+        filters
+      ),
       filters.text
     ),
     logLimit
@@ -34,6 +38,17 @@ function filterLevel(messages, filters) {
   return messages.filter((message) => {
     return filters.get(message.level) === true
       || [MESSAGE_TYPE.COMMAND, MESSAGE_TYPE.RESULT].includes(message.type);
+  });
+}
+
+function filterNetwork(messages, filters) {
+  return messages.filter((message) => {
+    return (
+      message.source !== MESSAGE_SOURCE.NETWORK
+      || (filters.get("network") === true && message.isXHR === false)
+      || (filters.get("netxhr") === true && message.isXHR === true)
+      || [MESSAGE_TYPE.COMMAND, MESSAGE_TYPE.RESULT].includes(message.type)
+    );
   });
 }
 

--- a/devtools/client/webconsole/new-console-output/store.js
+++ b/devtools/client/webconsole/new-console-output/store.js
@@ -20,6 +20,8 @@ function configureStore() {
       warn: Services.prefs.getBoolPref("devtools.webconsole.filter.warn"),
       info: Services.prefs.getBoolPref("devtools.webconsole.filter.info"),
       log: Services.prefs.getBoolPref("devtools.webconsole.filter.log"),
+      network: Services.prefs.getBoolPref("devtools.webconsole.filter.network"),
+      netxhr: Services.prefs.getBoolPref("devtools.webconsole.filter.netxhr"),
     })
   };
 

--- a/devtools/client/webconsole/new-console-output/test/fixtures/stubs/consoleApi.js
+++ b/devtools/client/webconsole/new-console-output/test/fixtures/stubs/consoleApi.js
@@ -331,10 +331,10 @@ stubPreparedMessages.set("console.timeEnd('bar')", new ConsoleMessage({
 	"source": "console-api",
 	"type": "timeEnd",
 	"level": "log",
-	"messageText": "bar: 1.63ms",
+	"messageText": "bar: 1.65ms",
 	"parameters": null,
 	"repeat": 1,
-	"repeatId": "{\"id\":null,\"allowRepeating\":true,\"source\":\"console-api\",\"type\":\"timeEnd\",\"level\":\"log\",\"messageText\":\"bar: 1.63ms\",\"parameters\":null,\"repeatId\":null,\"stacktrace\":null,\"frame\":{\"source\":\"http://example.com/browser/devtools/client/webconsole/new-console-output/test/fixtures/stub-generators/test-tempfile.js?key=console.time(%27bar%27)\",\"line\":3,\"column\":1}}",
+	"repeatId": "{\"id\":null,\"allowRepeating\":true,\"source\":\"console-api\",\"type\":\"timeEnd\",\"level\":\"log\",\"messageText\":\"bar: 1.65ms\",\"parameters\":null,\"repeatId\":null,\"stacktrace\":null,\"frame\":{\"source\":\"http://example.com/browser/devtools/client/webconsole/new-console-output/test/fixtures/stub-generators/test-tempfile.js?key=console.time(%27bar%27)\",\"line\":3,\"column\":1}}",
 	"stacktrace": null,
 	"frame": {
 		"source": "http://example.com/browser/devtools/client/webconsole/new-console-output/test/fixtures/stub-generators/test-tempfile.js?key=console.time(%27bar%27)",
@@ -370,7 +370,7 @@ stubPackets.set("console.log('foobar', 'test')", {
 		},
 		"private": false,
 		"styles": [],
-		"timeStamp": 1474329261562,
+		"timeStamp": 1474572748928,
 		"timer": null,
 		"workerType": "none",
 		"category": "webdev"
@@ -404,7 +404,7 @@ stubPackets.set("console.log(undefined)", {
 		},
 		"private": false,
 		"styles": [],
-		"timeStamp": 1474329262588,
+		"timeStamp": 1474572751274,
 		"timer": null,
 		"workerType": "none",
 		"category": "webdev"
@@ -436,7 +436,7 @@ stubPackets.set("console.warn('danger, will robinson!')", {
 		},
 		"private": false,
 		"styles": [],
-		"timeStamp": 1474329263650,
+		"timeStamp": 1474572753315,
 		"timer": null,
 		"workerType": "none",
 		"category": "webdev"
@@ -470,7 +470,7 @@ stubPackets.set("console.log(NaN)", {
 		},
 		"private": false,
 		"styles": [],
-		"timeStamp": 1474329264822,
+		"timeStamp": 1474572755104,
 		"timer": null,
 		"workerType": "none",
 		"category": "webdev"
@@ -504,7 +504,7 @@ stubPackets.set("console.log(null)", {
 		},
 		"private": false,
 		"styles": [],
-		"timeStamp": 1474329265855,
+		"timeStamp": 1474572756794,
 		"timer": null,
 		"workerType": "none",
 		"category": "webdev"
@@ -536,7 +536,7 @@ stubPackets.set("console.log('鼬')", {
 		},
 		"private": false,
 		"styles": [],
-		"timeStamp": 1474329266922,
+		"timeStamp": 1474572758502,
 		"timer": null,
 		"workerType": "none",
 		"category": "webdev"
@@ -565,7 +565,7 @@ stubPackets.set("console.clear()", {
 			"userContextId": 0
 		},
 		"private": false,
-		"timeStamp": 1474329267971,
+		"timeStamp": 1474572760296,
 		"timer": null,
 		"workerType": "none",
 		"styles": [],
@@ -600,7 +600,7 @@ stubPackets.set("console.count('bar')", {
 			"userContextId": 0
 		},
 		"private": false,
-		"timeStamp": 1474329269084,
+		"timeStamp": 1474572762158,
 		"timer": null,
 		"workerType": "none",
 		"styles": [],
@@ -654,7 +654,7 @@ stubPackets.set("console.assert(false, {message: 'foobar'})", {
 		},
 		"private": false,
 		"styles": [],
-		"timeStamp": 1474329270125,
+		"timeStamp": 1474572764156,
 		"timer": null,
 		"stacktrace": [
 			{
@@ -695,7 +695,7 @@ stubPackets.set("console.log('hello \nfrom \rthe \"string world!')", {
 		},
 		"private": false,
 		"styles": [],
-		"timeStamp": 1474329271256,
+		"timeStamp": 1474572765984,
 		"timer": null,
 		"workerType": "none",
 		"category": "webdev"
@@ -727,7 +727,7 @@ stubPackets.set("console.log('úṇĩçödê țĕșť')", {
 		},
 		"private": false,
 		"styles": [],
-		"timeStamp": 1474329272298,
+		"timeStamp": 1474572767825,
 		"timer": null,
 		"workerType": "none",
 		"category": "webdev"
@@ -756,7 +756,7 @@ stubPackets.set("console.trace()", {
 			"userContextId": 0
 		},
 		"private": false,
-		"timeStamp": 1474329273375,
+		"timeStamp": 1474572770002,
 		"timer": null,
 		"stacktrace": [
 			{
@@ -811,10 +811,10 @@ stubPackets.set("console.time('bar')", {
 			"userContextId": 0
 		},
 		"private": false,
-		"timeStamp": 1474329274410,
+		"timeStamp": 1474572772142,
 		"timer": {
 			"name": "bar",
-			"started": 618.57
+			"started": 1157.78
 		},
 		"workerType": "none",
 		"styles": [],
@@ -846,9 +846,9 @@ stubPackets.set("console.timeEnd('bar')", {
 			"userContextId": 0
 		},
 		"private": false,
-		"timeStamp": 1474329274411,
+		"timeStamp": 1474572772143,
 		"timer": {
-			"duration": 1.3249999999999318,
+			"duration": 1.6549999999999727,
 			"name": "bar"
 		},
 		"workerType": "none",

--- a/devtools/client/webconsole/new-console-output/test/fixtures/stubs/networkEvent.js
+++ b/devtools/client/webconsole/new-console-output/test/fixtures/stubs/networkEvent.js
@@ -24,7 +24,6 @@ stubPreparedMessages.set("GET request", new NetworkEventMessage({
 	},
 	"response": {},
 	"source": "network",
-	"type": "log"
 }));
 
 stubPreparedMessages.set("XHR GET request", new NetworkEventMessage({
@@ -38,7 +37,6 @@ stubPreparedMessages.set("XHR GET request", new NetworkEventMessage({
 	},
 	"response": {},
 	"source": "network",
-	"type": "log"
 }));
 
 stubPreparedMessages.set("XHR POST request", new NetworkEventMessage({
@@ -52,7 +50,7 @@ stubPreparedMessages.set("XHR POST request", new NetworkEventMessage({
 	},
 	"response": {},
 	"source": "network",
-	"type": "log"
+	"type": "networkEvent"
 }));
 
 
@@ -61,8 +59,8 @@ stubPackets.set("GET request", {
 	"type": "networkEvent",
 	"eventActor": {
 		"actor": "server1.conn0.child1/netEvent29",
-		"startedDateTime": "2016-09-14T02:38:18.046Z",
-		"timeStamp": 1473820698046,
+		"startedDateTime": "2016-09-22T05:52:47.967Z",
+		"timeStamp": 1474523567967,
 		"url": "http://example.com/browser/devtools/client/webconsole/new-console-output/test/fixtures/stub-generators/inexistent.html",
 		"method": "GET",
 		"isXHR": false,
@@ -102,8 +100,8 @@ stubPackets.set("XHR GET request", {
 	"type": "networkEvent",
 	"eventActor": {
 		"actor": "server1.conn1.child1/netEvent29",
-		"startedDateTime": "2016-09-14T02:38:18.812Z",
-		"timeStamp": 1473820698812,
+		"startedDateTime": "2016-09-22T05:52:50.588Z",
+		"timeStamp": 1474523570588,
 		"url": "http://example.com/browser/devtools/client/webconsole/new-console-output/test/fixtures/stub-generators/inexistent.html",
 		"method": "GET",
 		"isXHR": true,
@@ -143,8 +141,8 @@ stubPackets.set("XHR POST request", {
 	"type": "networkEvent",
 	"eventActor": {
 		"actor": "server1.conn2.child1/netEvent29",
-		"startedDateTime": "2016-09-14T02:38:19.483Z",
-		"timeStamp": 1473820699483,
+		"startedDateTime": "2016-09-22T05:52:52.097Z",
+		"timeStamp": 1474523572097,
 		"url": "http://example.com/browser/devtools/client/webconsole/new-console-output/test/fixtures/stub-generators/inexistent.html",
 		"method": "POST",
 		"isXHR": true,

--- a/devtools/client/webconsole/new-console-output/test/store/filters.test.js
+++ b/devtools/client/webconsole/new-console-output/test/store/filters.test.js
@@ -13,6 +13,7 @@ const { getAllFilters } = require("devtools/client/webconsole/new-console-output
 const { setupStore } = require("devtools/client/webconsole/new-console-output/test/helpers");
 const { MESSAGE_LEVEL } = require("devtools/client/webconsole/new-console-output/constants");
 const { stubPackets } = require("devtools/client/webconsole/new-console-output/test/fixtures/stubs/index");
+const { stubPreparedMessages } = require("devtools/client/webconsole/new-console-output/test/fixtures/stubs/index");
 
 describe("Filtering", () => {
   let store;
@@ -57,6 +58,30 @@ describe("Filtering", () => {
 
       let messages = getAllMessages(store.getState());
       expect(messages.size).toEqual(numMessages - 1);
+    });
+
+    it("filters xhr messages", () => {
+      let message = stubPreparedMessages.get("XHR GET request");
+      store.dispatch(messageAdd(message));
+
+      let messages = getAllMessages(store.getState());
+      expect(messages.size).toEqual(numMessages + 1);
+
+      store.dispatch(actions.filterToggle("netxhr"));
+      messages = getAllMessages(store.getState());
+      expect(messages.size).toEqual(numMessages);
+    });
+
+    it("filters network messages", () => {
+      let message = stubPreparedMessages.get("GET request");
+      store.dispatch(messageAdd(message));
+
+      let messages = getAllMessages(store.getState());
+      expect(messages.size).toEqual(numMessages + 1);
+
+      store.dispatch(actions.filterToggle("network"));
+      messages = getAllMessages(store.getState());
+      expect(messages.size).toEqual(numMessages);
     });
   });
 
@@ -137,13 +162,17 @@ describe("Clear filters", () => {
 
     // Setup test case
     store.dispatch(actions.filterToggle(MESSAGE_LEVEL.ERROR));
+    store.dispatch(actions.filterToggle("netxhr"));
     store.dispatch(actions.filterTextSet("foobar"));
+
     let filters = getAllFilters(store.getState());
     expect(filters.toJS()).toEqual({
       "debug": true,
       "error": false,
       "info": true,
       "log": true,
+      "network": true,
+      "netxhr": false,
       "warn": true,
       "text": "foobar"
     });
@@ -156,6 +185,8 @@ describe("Clear filters", () => {
       "error": true,
       "info": true,
       "log": true,
+      "network": true,
+      "netxhr": true,
       "warn": true,
       "text": ""
     });


### PR DESCRIPTION
Adds buttons in the filter-bar like specified in the mockups : "XHR" and "Requests",
which respectively filter xhr network messages and non-xhr network messages.

Fixes #290
## Testing instructions
1. `npm test`
