### PR TITLE
Bug 1305064 - New console frontend: Fix cached message handling.

### DIFF
--- a/devtools/client/webconsole/webconsole.js
+++ b/devtools/client/webconsole/webconsole.js
@@ -3298,6 +3298,9 @@ WebConsoleConnectionProxy.prototype = {
     messages.sort((a, b) => a.timeStamp - b.timeStamp);
 
     if (this.webConsoleFrame.NEW_CONSOLE_OUTPUT_ENABLED) {
+      // Filter out CSS page errors.
+      messages = messages.filter(message => !(message._type == "PageError"
+          && Utils.categoryForScriptError(message) === CATEGORY_CSS));
       for (let packet of messages) {
         this.dispatchMessageAdd(packet);
       }


### PR DESCRIPTION
Fixes #305 
## Testing instructions
1. Go to twitter.com
2. Open the console

Before you would see lots of CSS page errors. Now you do not.

@bgrins this is ready for review
