### PR TITLE
Bug 1306099 - New console frontend: Fix scrolling

### DIFF
--- a/devtools/client/webconsole/new-console-output/components/console-output.js
+++ b/devtools/client/webconsole/new-console-output/components/console-output.js
@@ -28,7 +28,7 @@ const ConsoleOutput = createClass({
     onViewSourceInDebugger: PropTypes.func.isRequired,
     openNetworkPanel: PropTypes.func.isRequired,
     openLink: PropTypes.func.isRequired,
-    autoscroll: PropTypes.object.isRequired,
+    autoscroll: PropTypes.bool.isRequired,
   },
 
   componentDidMount() {
@@ -36,6 +36,10 @@ const ConsoleOutput = createClass({
   },
 
   componentWillUpdate(nextProps, nextState) {
+    if (!this.outputNode) {
+      return;
+    }
+
     const outputNode = this.outputNode;
 
     // Figure out if we are at the bottom. If so, then any new message should be scrolled
@@ -86,9 +90,7 @@ const ConsoleOutput = createClass({
       dom.div({
         className: "webconsole-output",
         ref: node => {
-          if (node !== null) {
-            this.outputNode = node;
-          }
+          this.outputNode = node;
         },
       }, messageNodes
       )

--- a/devtools/client/webconsole/new-console-output/components/console-output.js
+++ b/devtools/client/webconsole/new-console-output/components/console-output.js
@@ -13,6 +13,7 @@ const ReactDOM = require("devtools/client/shared/vendor/react-dom");
 const { connect } = require("devtools/client/shared/vendor/react-redux");
 
 const { getAllMessages, getAllMessagesUiById, getAllMessagesTableDataById } = require("devtools/client/webconsole/new-console-output/selectors/messages");
+const { getScrollSetting } = require("devtools/client/webconsole/new-console-output/selectors/ui");
 const MessageContainer = createFactory(require("devtools/client/webconsole/new-console-output/components/message-container").MessageContainer);
 
 const ConsoleOutput = createClass({
@@ -27,25 +28,33 @@ const ConsoleOutput = createClass({
     onViewSourceInDebugger: PropTypes.func.isRequired,
     openNetworkPanel: PropTypes.func.isRequired,
     openLink: PropTypes.func.isRequired,
+    autoscroll: PropTypes.object.isRequired,
   },
 
-  componentWillUpdate() {
-    let node = ReactDOM.findDOMNode(this);
-    if (node.lastChild) {
-      this.shouldScrollBottom = isScrolledToBottom(node.lastChild, node);
+  componentDidMount() {
+    scrollToBottom(this.outputNode);
+  },
+
+  componentWillUpdate(nextProps, nextState) {
+    const outputNode = this.outputNode;
+
+    // Figure out if we are at the bottom. If so, then any new message should be scrolled
+    // into view.
+    if (this.props.autoscroll && outputNode.lastChild) {
+      this.shouldScrollBottom = isScrolledToBottom(outputNode.lastChild, outputNode);
     }
   },
 
   componentDidUpdate() {
     if (this.shouldScrollBottom) {
-      let node = ReactDOM.findDOMNode(this);
-      node.scrollTop = node.scrollHeight;
+      scrollToBottom(this.outputNode);
     }
   },
 
   render() {
     let {
       dispatch,
+      autoscroll,
       hudProxyClient,
       messages,
       messagesUi,
@@ -69,14 +78,27 @@ const ConsoleOutput = createClass({
           openLink,
           open: messagesUi.includes(message.id),
           tableData: messagesTableData.get(message.id),
+          autoscroll,
         })
       );
     });
     return (
-      dom.div({className: "webconsole-output"}, messageNodes)
+      dom.div({
+        className: "webconsole-output",
+        ref: node => {
+          if (node !== null) {
+            this.outputNode = node;
+          }
+        },
+      }, messageNodes
+      )
     );
   }
 });
+
+function scrollToBottom(node) {
+  node.scrollTop = node.scrollHeight;
+}
 
 function isScrolledToBottom(outputNode, scrollNode) {
   let lastNodeHeight = outputNode.lastChild ?
@@ -90,6 +112,7 @@ function mapStateToProps(state) {
     messages: getAllMessages(state),
     messagesUi: getAllMessagesUiById(state),
     messagesTableData: getAllMessagesTableDataById(state),
+    autoscroll: getScrollSetting(state),
   };
 }
 

--- a/devtools/client/webconsole/new-console-output/components/message-container.js
+++ b/devtools/client/webconsole/new-console-output/components/message-container.js
@@ -38,6 +38,7 @@ const MessageContainer = createClass({
     openLink: PropTypes.func.isRequired,
     open: PropTypes.bool.isRequired,
     hudProxyClient: PropTypes.object.isRequired,
+    autoscroll: PropTypes.bool.isRequired,
   },
 
   getDefaultProps: function () {
@@ -54,30 +55,10 @@ const MessageContainer = createClass({
   },
 
   render() {
-    const {
-      dispatch,
-      message,
-      sourceMapService,
-      onViewSourceInDebugger,
-      openNetworkPanel,
-      openLink,
-      open,
-      tableData,
-      hudProxyClient,
-    } = this.props;
+    const { message } = this.props;
 
     let MessageComponent = createFactory(getMessageComponent(message));
-    return MessageComponent({
-      dispatch,
-      message,
-      sourceMapService,
-      onViewSourceInDebugger,
-      openNetworkPanel,
-      openLink,
-      open,
-      tableData,
-      hudProxyClient,
-    });
+    return MessageComponent(this.props);
   }
 });
 

--- a/devtools/client/webconsole/new-console-output/components/message-types/console-command.js
+++ b/devtools/client/webconsole/new-console-output/components/message-types/console-command.js
@@ -17,6 +17,7 @@ ConsoleCommand.displayName = "ConsoleCommand";
 
 ConsoleCommand.propTypes = {
   message: PropTypes.object.isRequired,
+  autoscroll: PropTypes.bool.isRequired,
 };
 
 /**
@@ -27,14 +28,15 @@ function ConsoleCommand(props) {
     source,
     type,
     level,
-    messageText: messageBody
+    messageText: messageBody,
   } = props.message;
 
   const childProps = {
     source,
     type,
     level,
-    messageBody
+    messageBody,
+    scrollToMessage: props.autoscroll,
   };
   return Message(childProps);
 }

--- a/devtools/client/webconsole/new-console-output/components/message-types/evaluation-result.js
+++ b/devtools/client/webconsole/new-console-output/components/message-types/evaluation-result.js
@@ -43,6 +43,7 @@ function EvaluationResult(props) {
     level,
     topLevelClasses,
     messageBody,
+    scrollToMessage: props.autoscroll,
   };
   return Message(childProps);
 }

--- a/devtools/client/webconsole/new-console-output/components/message.js
+++ b/devtools/client/webconsole/new-console-output/components/message.js
@@ -8,6 +8,7 @@
 
 // React & Redux
 const {
+  createClass,
   createFactory,
   DOM: dom,
   PropTypes
@@ -19,107 +20,125 @@ const MessageRepeat = createFactory(require("devtools/client/webconsole/new-cons
 const FrameView = createFactory(require("devtools/client/shared/components/frame"));
 const StackTrace = createFactory(require("devtools/client/shared/components/stack-trace"));
 
-Message.displayName = "Message";
+const Message = createClass({
+  displayName: "Message",
 
-Message.propTypes = {
-  open: PropTypes.bool,
-  source: PropTypes.string.isRequired,
-  type: PropTypes.string.isRequired,
-  level: PropTypes.string.isRequired,
-  topLevelClasses: PropTypes.array,
-  messageBody: PropTypes.any.isRequired,
-  repeat: PropTypes.any,
-  frame: PropTypes.any,
-  attachment: PropTypes.any,
-  stacktrace: PropTypes.any,
-  messageId: PropTypes.string,
-  onViewSourceInDebugger: PropTypes.func,
-  sourceMapService: PropTypes.any,
-};
+  propTypes: {
+    open: PropTypes.bool,
+    source: PropTypes.string.isRequired,
+    type: PropTypes.string.isRequired,
+    level: PropTypes.string.isRequired,
+    topLevelClasses: PropTypes.array,
+    messageBody: PropTypes.any.isRequired,
+    repeat: PropTypes.any,
+    frame: PropTypes.any,
+    attachment: PropTypes.any,
+    stacktrace: PropTypes.any,
+    messageId: PropTypes.string,
+    scrollToMessage: PropTypes.bool.isRequired,
+    onViewSourceInDebugger: PropTypes.func,
+    sourceMapService: PropTypes.any,
+  },
 
-Message.defaultProps = {
-  topLevelClasses: [],
-};
+  getDefaultProps() {
+    return {
+      topLevelClasses: [],
+    };
+  },
 
-function Message(props) {
-  const {
-    messageId,
-    open,
-    source,
-    type,
-    level,
-    topLevelClasses,
-    messageBody,
-    frame,
-    stacktrace,
-    onViewSourceInDebugger,
-    sourceMapService,
-    dispatch,
-  } = props;
+  componentDidMount() {
+    if (this.props.scrollToMessage && this.messageNode) {
+      this.messageNode.scrollIntoView();
+    }
+  },
 
-  topLevelClasses.push("message", source, type, level);
-  if (open) {
-    topLevelClasses.push("open");
-  }
-
-  const icon = MessageIcon({level});
-
-  // Figure out if there is an expandable part to the message.
-  let attachment = null;
-  if (props.attachment) {
-    attachment = props.attachment;
-  } else if (stacktrace) {
-    const child = open ? StackTrace({
-      stacktrace: stacktrace,
-      onViewSourceInDebugger: onViewSourceInDebugger
-    }) : null;
-    attachment = dom.div({ className: "stacktrace devtools-monospace" }, child);
-  }
-
-  // If there is an expandable part, make it collapsible.
-  let collapse = null;
-  if (attachment) {
-    collapse = CollapseButton({
+  render() {
+    const {
+      messageId,
       open,
-      onClick: function () {
-        if (open) {
-          dispatch(actions.messageClose(messageId));
-        } else {
-          dispatch(actions.messageOpen(messageId));
-        }
-      },
-    });
-  }
-
-  const repeat = props.repeat ? MessageRepeat({repeat: props.repeat}) : null;
-
-  // Configure the location.
-  const shouldRenderFrame = frame && frame.source !== "debugger eval code";
-  const location = dom.span({ className: "message-location devtools-monospace" },
-    shouldRenderFrame ? FrameView({
+      source,
+      type,
+      level,
+      topLevelClasses,
+      messageBody,
       frame,
-      onClick: onViewSourceInDebugger,
-      showEmptyPathAsHost: true,
-      sourceMapService
-    }) : null
-  );
+      stacktrace,
+      onViewSourceInDebugger,
+      sourceMapService,
+      dispatch,
+    } = this.props;
 
-  return dom.div({ className: topLevelClasses.join(" ") },
-    // @TODO add timestamp
-    // @TODO add indent if necessary
-    icon,
-    collapse,
-    dom.span({ className: "message-body-wrapper" },
-      dom.span({ className: "message-flex-body" },
-        dom.span({ className: "message-body devtools-monospace" },
-          messageBody
+    topLevelClasses.push("message", source, type, level);
+    if (open) {
+      topLevelClasses.push("open");
+    }
+
+    const icon = MessageIcon({level});
+
+    // Figure out if there is an expandable part to the message.
+    let attachment = null;
+    if (this.props.attachment) {
+      attachment = this.props.attachment;
+    } else if (stacktrace) {
+      const child = open ? StackTrace({
+        stacktrace: stacktrace,
+        onViewSourceInDebugger: onViewSourceInDebugger
+      }) : null;
+      attachment = dom.div({ className: "stacktrace devtools-monospace" }, child);
+    }
+
+    // If there is an expandable part, make it collapsible.
+    let collapse = null;
+    if (attachment) {
+      collapse = CollapseButton({
+        open,
+        onClick: function () {
+          if (open) {
+            dispatch(actions.messageClose(messageId));
+          } else {
+            dispatch(actions.messageOpen(messageId));
+          }
+        },
+      });
+    }
+
+    const repeat = this.props.repeat ? MessageRepeat({repeat: this.props.repeat}) : null;
+
+    // Configure the location.
+    const shouldRenderFrame = frame && frame.source !== "debugger eval code";
+    const location = dom.span({ className: "message-location devtools-monospace" },
+      shouldRenderFrame ? FrameView({
+        frame,
+        onClick: onViewSourceInDebugger,
+        showEmptyPathAsHost: true,
+        sourceMapService
+      }) : null
+    );
+
+    return dom.div({
+      className: topLevelClasses.join(" "),
+      ref: node => {
+        if (node) {
+          this.messageNode = node;
+        }
+      }
+    },
+      // @TODO add timestamp
+      // @TODO add indent if necessary
+      icon,
+      collapse,
+      dom.span({ className: "message-body-wrapper" },
+        dom.span({ className: "message-flex-body" },
+          dom.span({ className: "message-body devtools-monospace" },
+            messageBody
+          ),
+          repeat,
+          location
         ),
-        repeat,
-        location
-      ),
-      attachment
-    )
-  );
-}
+        attachment
+      )
+    );
+  }
+});
 
 module.exports = Message;

--- a/devtools/client/webconsole/new-console-output/components/message.js
+++ b/devtools/client/webconsole/new-console-output/components/message.js
@@ -118,9 +118,7 @@ const Message = createClass({
     return dom.div({
       className: topLevelClasses.join(" "),
       ref: node => {
-        if (node) {
-          this.messageNode = node;
-        }
+        this.messageNode = node;
       }
     },
       // @TODO add timestamp

--- a/devtools/client/webconsole/new-console-output/reducers/ui.js
+++ b/devtools/client/webconsole/new-console-output/reducers/ui.js
@@ -5,17 +5,28 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 
-const constants = require("devtools/client/webconsole/new-console-output/constants");
+const {
+  FILTER_BAR_TOGGLE,
+  MESSAGE_ADD,
+} = require("devtools/client/webconsole/new-console-output/constants");
 const Immutable = require("devtools/client/shared/vendor/immutable");
 
 const UiState = Immutable.Record({
   filterBarVisible: false,
   filteredMessageVisible: false,
+  autoscroll: true,
 });
 
 function ui(state = new UiState(), action) {
+  // Autoscroll should be set for all action types. If the last action was not message
+  // add, then turn it off. This prevents us from scrolling after someone toggles a
+  // filter, or to the bottom of the attachement when an expandable message at the bottom
+  // of the list is expanded. It does depend on the MESSAGE_ADD action being the last in
+  // its batch, though.
+  state = state.set("autoscroll", action.type == MESSAGE_ADD);
+
   switch (action.type) {
-    case constants.FILTER_BAR_TOGGLE:
+    case FILTER_BAR_TOGGLE:
       return state.set("filterBarVisible", !state.filterBarVisible);
   }
 

--- a/devtools/client/webconsole/new-console-output/selectors/ui.js
+++ b/devtools/client/webconsole/new-console-output/selectors/ui.js
@@ -3,10 +3,18 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 "use strict";
 
 function getAllUi(state) {
   return state.ui;
 }
 
-exports.getAllUi = getAllUi;
+function getScrollSetting(state) {
+  return getAllUi(state).autoscroll;
+}
+
+module.exports = {
+  getAllUi,
+  getScrollSetting,
+};


### PR DESCRIPTION
Fixes #255, fixes #315 

@bgrins, do you have time for review?
## Testing instructions
1. You can test that it scrolls to the bottom of cached messages with 

```
data:text/html;charset=utf-8,<p>Test keyboard accessibility</p>
  <script>
    for (let i = 1; i <= 100; i++) {
      console.log("console message " + i);
    }
  </script>
```
1. After that you can scroll to the top and then enter a command. This fixes #255
2. Then add a `console.trace()` call. Close it and scroll so that the area that would expand is hidden. Then open again. It won't push the scroll down. This fixes #315.
